### PR TITLE
Add example usage of RUST_LOG with a pointer to the env_logger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,15 @@ fn main() {
     // ...
 }
 ```
+
+Then when running the executable, specify a value for the `RUST_LOG`
+environment variable that corresponds with the log messages you want to show.
+
+```bash
+$ RUST_LOG=info ./main
+starting up
+```
+
+See the [`env_logger` documentation](http://rust-lang.github.io/log/env_logger/)
+for the `RUST_LOG` values that can be used to get log messages with different
+levels or filtered to different modules.


### PR DESCRIPTION
A [recent blog post](https://techsaju.wordpress.com/2015/09/12/logging-in-rust-using-log/) shows that using the RUST_LOG variable, and the necessity of using it to get log messages other than at log level debug, isn't especially clear from the README, which is the first page people will likely end up on.
