### PR TITLE
Statically disable debug logging in optimized builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ language: rust
 sudo: false
 rust:
   - 1.0.0
+  - stable
   - beta
   - nightly
 script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo test --verbose --manifest-path env/Cargo.toml
+  - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml
+  - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml --release
   - cargo doc --manifest-path env/Cargo.toml
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,18 @@ harness = false
 
 [dependencies]
 libc = "0.1"
+
+[features]
+max_level_off   = []
+max_level_error = []
+max_level_warn  = []
+max_level_info  = []
+max_level_debug = []
+max_level_trace = []
+
+release_max_level_off   = []
+release_max_level_error = []
+release_max_level_warn  = []
+release_max_level_info  = []
+release_max_level_debug = []
+release_max_level_trace = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,6 +563,40 @@ pub fn max_log_level() -> LogLevelFilter {
     unsafe { mem::transmute(MAX_LOG_LEVEL_FILTER.load(Ordering::Relaxed)) }
 }
 
+#[inline(always)]
+#[doc(hidden)]
+pub fn __static_max_level() -> LogLevelFilter {
+    if !cfg!(debug_assertions) {
+        // This is a release build. Check `release_max_level_*` first.
+        if cfg!(feature = "release_max_level_off") {
+            return LogLevelFilter::Off
+        } else if cfg!(feature = "release_max_level_error") {
+            return LogLevelFilter::Error
+        } else if cfg!(feature = "release_max_level_warn") {
+            return LogLevelFilter::Warn
+        } else if cfg!(feature = "release_max_level_info") {
+            return LogLevelFilter::Info
+        } else if cfg!(feature = "release_max_level_debug") {
+            return LogLevelFilter::Debug
+        } else if cfg!(feature = "release_max_level_trace") {
+            return LogLevelFilter::Trace
+        }
+    }
+    if cfg!(feature = "max_level_off") {
+        LogLevelFilter::Off
+    } else if cfg!(feature = "max_level_error") {
+        LogLevelFilter::Error
+    } else if cfg!(feature = "max_level_warn") {
+        LogLevelFilter::Warn
+    } else if cfg!(feature = "max_level_info") {
+        LogLevelFilter::Info
+    } else if cfg!(feature = "max_level_debug") {
+        LogLevelFilter::Debug
+    } else {
+        LogLevelFilter::Trace
+    }
+}
+
 /// Sets the global logger.
 ///
 /// The `make_logger` closure is passed a `MaxLogLevel` object, which the

--- a/tests/max_level_features/Cargo.toml
+++ b/tests/max_level_features/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "optimized"
+version = "0.1.0"
+
+[[bin]]
+name = "max_level_features"
+path = "main.rs"
+
+[dependencies.log]
+path = "../.."
+features = ["max_level_debug", "release_max_level_info"]

--- a/tests/max_level_features/main.rs
+++ b/tests/max_level_features/main.rs
@@ -1,0 +1,72 @@
+#[macro_use] extern crate log;
+
+use std::sync::{Arc, Mutex};
+use log::{LogLevel, set_logger, LogLevelFilter, Log, LogRecord, LogMetadata};
+use log::MaxLogLevelFilter;
+
+struct State {
+    last_log: Mutex<Option<LogLevel>>,
+    filter: MaxLogLevelFilter,
+}
+
+struct Logger(Arc<State>);
+
+impl Log for Logger {
+    fn enabled(&self, _: &LogMetadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &LogRecord) {
+        *self.0.last_log.lock().unwrap() = Some(record.level());
+    }
+}
+
+fn main() {
+    let mut a = None;
+    set_logger(|max| {
+        let me = Arc::new(State {
+            last_log: Mutex::new(None),
+            filter: max,
+        });
+        a = Some(me.clone());
+        Box::new(Logger(me))
+    }).unwrap();
+    let a = a.unwrap();
+
+    test(&a, LogLevelFilter::Off);
+    test(&a, LogLevelFilter::Error);
+    test(&a, LogLevelFilter::Warn);
+    test(&a, LogLevelFilter::Info);
+    test(&a, LogLevelFilter::Debug);
+    test(&a, LogLevelFilter::Trace);
+}
+
+fn test(a: &State, filter: LogLevelFilter) {
+    a.filter.set(filter);
+    error!("");
+    last(&a, t(LogLevel::Error, filter));
+    warn!("");
+    last(&a, t(LogLevel::Warn, filter));
+    info!("");
+    last(&a, t(LogLevel::Info, filter));
+
+    debug!("");
+    if cfg!(debug_assertions) {
+        last(&a, t(LogLevel::Debug, filter));
+    } else {
+        last(&a, None);
+    }
+
+    trace!("");
+    last(&a, None);
+
+    fn t(lvl: LogLevel, filter: LogLevelFilter) -> Option<LogLevel> {
+        if lvl <= filter {Some(lvl)} else {None}
+    }
+}
+
+fn last(state: &State, expected: Option<LogLevel>) {
+    let mut lvl = state.last_log.lock().unwrap();
+    assert_eq!(*lvl, expected);
+    *lvl = None;
+}


### PR DESCRIPTION
This PR modifies `log!` and associated macros to disable logging at compile time for the Debug and Trace log levels when the `debug_assertions` option is disabled (which it is by default when optimizations are enabled).

The goal of this change is to make it easy to leave debug logging in place throughout a project and its dependencies, but to pay for it only in debug builds, and have it completely optimized out in release builds.

The `log_level` configuration option provides an existing way to do this. However, in practice there is no supported way to toggle `log_level` for a package *and* all of its dependencies when building with Cargo.  However, Cargo does provide per-profile options for controlling rustc's built-in `debug_assertions` option. This option is a pretty good fit for debug logging, since it is intended to statically disable code that is useful for debugging but may have a performance cost.  In fact, rustc's internal liblog [already uses it this way for its `debug!` logging macro](https://github.com/rust-lang/rust/blob/168a23ebe1729386138fa71643382fdd64fac205/src/liblog/macros.rs#L160).

This PR is alternative to rust-lang/cargo#1948 which was closed by @alexcrichton in favor of “options that are local to the `log` crate itself.”  Compared to the Cargo PR, this one is not as configurable, but does not require any external changes.