### PR TITLE
[docs] Use a better example for log_enabled!

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -123,10 +123,12 @@ macro_rules! trace {
 ///
 /// # fn foo() {
 /// if log_enabled!(Debug) {
-///     debug!("expensive debug data: {}", expensive_call());
+///     let data = expensive_call();
+///     debug!("expensive debug data: {} {}", data.x, data.y);
 /// }
 /// # }
-/// # fn expensive_call() -> u32 { 0 }
+/// # struct Data { x: u32, y: u32 }
+/// # fn expensive_call() -> Data { Data { x: 0, y: 0 } }
 /// # fn main() {}
 /// ```
 #[macro_export]


### PR DESCRIPTION
The previous example code for the `log_enabled!` macro doesn't properly demonstrate why to use it, since the use of `log_enabled!` doesn't improve anything.  (The `debug!` macro already prevents the expensive call when debug logging is disabled.)

This changes the example to one that has better performance compared to `debug!` alone.

r? @sfackler