### PR TITLE
Added "force-stdout" compilation feature

### DIFF
--- a/env/Cargo.toml
+++ b/env/Cargo.toml
@@ -17,3 +17,7 @@ path = ".."
 
 [dependencies]
 regex = "0.1"
+
+[features]
+default = []
+force-stdout = []

--- a/env/src/lib.rs
+++ b/env/src/lib.rs
@@ -314,7 +314,11 @@ impl Log for Logger {
             }
         }
 
-        let _ = writeln!(&mut io::stderr(), "{}", (self.format)(record));
+        if cfg!(feature="force-stdout") {
+            let _ = writeln!(io::stdout(), "{}", (self.format)(record));
+        } else {
+            let _ = writeln!(io::stderr(), "{}", (self.format)(record));
+        };
     }
 }
 


### PR DESCRIPTION
Hi, I'd like to have a way to force all logs from env_logger to go to stdout instead of stderr.

As there's currently no way to pass in configuration to the env_logger (see #62), I settled for a compilation feature. That might even be the better option, because the user can choose at compile time whether he/she wants to log to stderr or not.

In my case I need it to build a Docker container. The Docker "logs" command only considers stdout, as far as I know.

Honestly I didn't manage to test this. When I pointed an existing project at the code directory (even without my changes), logging stops. But that's probably just a problem on my side.

If you like this approach / change, I can also provide documentation.