### PR TITLE
Add support for no_std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ rust:
   - nightly
 script:
   - cargo build --verbose
+  - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo build --verbose --no-default-features)
   - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo build --verbose --features nightly)
-  - cargo test --verbose
+  - ([ $TRAVIS_RUST_VERSION == 1.0.0 ] || cargo test --verbose)
+  - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --no-default-features)
   - cargo test --verbose --manifest-path env/Cargo.toml
   - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml
   - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "filters"
 harness = false
 
 [dependencies]
-libc = "0.2"
+libc = {version = "0.2", optional = true}
 
 [features]
 max_level_off   = []
@@ -35,3 +35,5 @@ release_max_level_debug = []
 release_max_level_trace = []
 
 nightly = []
+use_std = ["libc"]
+default = ["use_std"]

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,8 +1,18 @@
 #[macro_use] extern crate log;
 
 use std::sync::{Arc, Mutex};
-use log::{LogLevel, set_logger, LogLevelFilter, Log, LogRecord, LogMetadata};
+use log::{LogLevel, LogLevelFilter, Log, LogRecord, LogMetadata};
 use log::MaxLogLevelFilter;
+
+#[cfg(feature = "use_std")]
+use log::set_logger;
+#[cfg(not(feature = "use_std"))]
+fn set_logger<M>(make_logger: M) -> Result<(), log::SetLoggerError>
+    where M: FnOnce(MaxLogLevelFilter) -> Box<Log> {
+    unsafe {
+        log::set_logger_raw(|x| std::mem::transmute(make_logger(x)))
+    }
+}
 
 struct State {
     last_log: Mutex<Option<LogLevel>>,

--- a/tests/max_level_features/main.rs
+++ b/tests/max_level_features/main.rs
@@ -1,8 +1,18 @@
 #[macro_use] extern crate log;
 
 use std::sync::{Arc, Mutex};
-use log::{LogLevel, set_logger, LogLevelFilter, Log, LogRecord, LogMetadata};
+use log::{LogLevel, LogLevelFilter, Log, LogRecord, LogMetadata};
 use log::MaxLogLevelFilter;
+
+#[cfg(feature = "use_std")]
+use log::set_logger;
+#[cfg(not(feature = "use_std"))]
+fn set_logger<M>(make_logger: M) -> Result<(), log::SetLoggerError>
+    where M: FnOnce(MaxLogLevelFilter) -> Box<Log> {
+    unsafe {
+        log::set_logger_raw(|x| std::mem::transmute(make_logger(x)))
+    }
+}
 
 struct State {
     last_log: Mutex<Option<LogLevel>>,


### PR DESCRIPTION
Second attempt at support `no_std`, this time without splitting the crate into two. Instead, a `use_std` feature is used, which is enabled by default.

Fixes #13 