### PR TITLE
Stop trying to drop the logger in an atexit callback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ A lightweight logging facade for Rust
 name = "filters"
 harness = false
 
-[dependencies]
-libc = {version = "0.2", optional = true}
-
 [features]
 max_level_off   = []
 max_level_error = []
@@ -35,5 +32,5 @@ release_max_level_debug = []
 release_max_level_trace = []
 
 nightly = []
-use_std = ["libc"]
+use_std = []
 default = ["use_std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,9 +195,6 @@
 #[cfg(not(feature = "use_std"))]
 extern crate core as std;
 
-#[cfg(feature = "use_std")]
-extern crate libc;
-
 use std::cmp;
 #[cfg(feature = "use_std")]
 use std::error;
@@ -664,17 +661,10 @@ pub fn set_logger<M>(make_logger: M) -> Result<(), SetLoggerError>
 
     return match result {
         Ok(()) => {
-            assert_eq!(unsafe { libc::atexit(shutdown) }, 0);
             Ok(())
         }
         Err(_) => Err(SetLoggerError(())),
     };
-
-    extern fn shutdown() {
-        shutdown_logger_raw().map(|logger| unsafe {
-            mem::transmute::<_, Box<Log>>(logger);
-        }).ok();
-    }
 }
 
 /// Sets the global logger from a raw pointer.


### PR DESCRIPTION
Windows apparently runs these after killing all other threads, so the
shutdown process can deadlock if any of those threads was logging at
that point.

Closes #74