### PR TITLE
column in LogLocation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -579,6 +579,8 @@ pub struct LogLocation {
     pub __file: &'static str,
     #[doc(hidden)]
     pub __line: u32,
+    #[doc(hidden)]
+    pub __column: u32,
 }
 
 impl LogLocation {
@@ -595,6 +597,11 @@ impl LogLocation {
     /// The line containing the message.
     pub fn line(&self) -> u32 {
         self.__line
+    }
+
+    /// The column at which the message was logged.
+    pub fn column(&self) -> u32 {
+        self.__column
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,6 +18,7 @@
 macro_rules! log {
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         static _LOC: $crate::LogLocation = $crate::LogLocation {
+            __column: column!(),
             __line: line!(),
             __file: file!(),
             __module_path: module_path!(),


### PR DESCRIPTION
Since column!() macro is readily available I have added column() getter to LogLocation. It is probably not the most useful information for logging, but it is cheap and nice to have IMHO. 
