### PR TITLE
Make regex an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
   - cargo test --verbose
   - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --no-default-features)
   - cargo test --verbose --manifest-path env/Cargo.toml
+  - cargo test --verbose --manifest-path env/Cargo.toml --no-default-features
   - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml
   - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml --release
   - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo doc --no-deps --features nightly)

--- a/env/Cargo.toml
+++ b/env/Cargo.toml
@@ -11,13 +11,13 @@ An logging implementation for `log` which is configured via an environment
 variable.
 """
 
-[dependencies.log]
-version = "0.3"
-path = ".."
-
 [dependencies]
-regex = "0.1"
+log = { version = "0.3", path = ".." }
+regex = { version = "0.1", optional = true }
 
 [[test]]
 name = "regexp_filter"
 harness = false
+
+[features]
+default = ["regex"]

--- a/env/src/regex.rs
+++ b/env/src/regex.rs
@@ -1,0 +1,28 @@
+extern crate regex;
+
+use std::fmt;
+
+use self::regex::Regex;
+
+pub struct Filter {
+    inner: Regex,
+}
+
+impl Filter {
+    pub fn new(spec: &str) -> Result<Filter, String> {
+        match Regex::new(spec){
+            Ok(r) => Ok(Filter { inner: r }),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    pub fn is_match(&self, s: &str) -> bool {
+        self.inner.is_match(s)
+    }
+}
+
+impl fmt::Display for Filter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}

--- a/env/src/string.rs
+++ b/env/src/string.rs
@@ -1,0 +1,21 @@
+use std::fmt;
+
+pub struct Filter {
+    inner: String,
+}
+
+impl Filter {
+    pub fn new(spec: &str) -> Result<Filter, String> {
+        Ok(Filter { inner: spec.to_string() })
+    }
+
+    pub fn is_match(&self, s: &str) -> bool {
+        s.contains(&self.inner)
+    }
+}
+
+impl fmt::Display for Filter {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}


### PR DESCRIPTION
Not all uses of env-logger require a full regex engine for matching, for example
the compiler works with just simple substring matching. Additionally compiling
regex can often take quite a bit of time, so for those that would prefer the
filtering can be disabled.