### PR TITLE
Add ability to be used in rustc

### DIFF
--- a/env/src/lib.rs
+++ b/env/src/lib.rs
@@ -130,6 +130,11 @@
        html_root_url = "http://doc.rust-lang.org/env_logger/")]
 #![cfg_attr(test, deny(warnings))]
 
+// When compiled for the rustc compiler itself we want to make sure that this is
+// an unstable crate
+#![cfg_attr(rustbuild, feature(staged_api, rustc_private))]
+#![cfg_attr(rustbuild, unstable(feature = "rustc_private", issue = "27812"))]
+
 extern crate log;
 
 use std::env;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,11 @@
 
 #![cfg_attr(not(feature = "use_std"), no_std)]
 
+// When compiled for the rustc compiler itself we want to make sure that this is
+// an unstable crate
+#![cfg_attr(rustbuild, feature(staged_api, rustc_private))]
+#![cfg_attr(rustbuild, unstable(feature = "rustc_private", issue = "27812"))]
+
 #[cfg(not(feature = "use_std"))]
 extern crate core as std;
 


### PR DESCRIPTION
I'm prototyping support for pulling in crates.io crates into rustc and I believe
this'll be the support necessary for living in the sysroot.