### PR TITLE
Make log target configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,20 @@ test tests::it_adds_one ... ok
 
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 ```
+
+## Configuring log target
+
+By default, `env_logger` logs to stderr. If you want to log to stdout instead,
+you can use the `LogBuilder` to change the log target:
+
+```rust
+use std::env;
+use env_logger::{LogBuilder, LogTarget};
+
+let mut builder = LogBuilder::new();
+builder.target(LogTarget::Stdout);
+if env::var("RUST_LOG").is_ok() {
+    builder.parse(&env::var("RUST_LOG").unwrap());
+}
+builder.init().unwrap();
+```


### PR DESCRIPTION
Right now `env_logger` always logs to stderr. This might be undesireable in some cases.

This PR adds a way to configure the log target. It can be set to stdout if desired.

Note that writing to stdout is implemented with `println!` instead of `writeln!`, so that the output is properly captured in tests. See https://users.rust-lang.org/t/cargo-doesnt-capture-stderr-of-running-tests/9222/.

I did not find out how to properly add a test, but tested it manually. If you want a test to be added, pointers would be welcome.