### PR TITLE
add emoji to log level name for iOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,8 @@ static MAX_LOG_LEVEL_FILTER: AtomicUsize = ATOMIC_USIZE_INIT;
 
 static LOG_LEVEL_NAMES: [&'static str; 6] = ["OFF", "ERROR", "WARN", "INFO",
                                              "DEBUG", "TRACE"];
+static LOG_LEVEL_EMOJIES: [&'static str; 6] = ["", "❤️", "💛", "💙",
+                                             "💚", "💜"];
 
 /// An enum representing the available verbosity levels of the logging framework
 ///
@@ -368,6 +370,11 @@ impl LogLevel {
             5 => Some(LogLevel::Trace),
             _ => None
         }
+    }
+
+    /// Returns emoji representation of logging level
+    pub fn emoji(&self) -> &'static str {
+        LOG_LEVEL_EMOJIES[*self as usize]
     }
 
     /// Returns the most verbose logging level.


### PR DESCRIPTION
because we can't tweak Xcode 8 to use color in console
https://github.com/robbiehanson/XcodeColors/issues/88