### PR TITLE
Add serde impls to LogLevel and LogLevelFilter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,11 @@ before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo build --verbose
+  - cargo build --verbose --features serde
   - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo build --verbose --no-default-features)
   - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo build --verbose --features nightly)
   - cargo test --verbose
+  - cargo test --verbose --features serde
   - ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --no-default-features)
   - cargo test --verbose --manifest-path env/Cargo.toml
   - cargo test --verbose --manifest-path env/Cargo.toml --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ default = ["use_std"]
 [badges]
 travis-ci = { repository = "rust-lang-nursery/log" }
 appveyor = { repository = "alexcrichton/log" }
+
+[dependencies]
+serde = { version = ">= 1.0.7", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,7 @@ travis-ci = { repository = "rust-lang-nursery/log" }
 appveyor = { repository = "alexcrichton/log" }
 
 [dependencies]
-serde = { version = ">= 1.0.7", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "*"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,4 +15,5 @@ build: false
 
 test_script:
   - cargo test --verbose
+  - cargo test --verbose --features serde
   - cargo test --manifest-path env/Cargo.toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,9 @@
 
 #[cfg(not(feature = "use_std"))]
 extern crate core as std;
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
 
 use std::cmp;
 #[cfg(feature = "use_std")]
@@ -283,7 +286,7 @@ static LEVEL_PARSE_ERROR: &'static str = "attempted to convert a string that doe
 /// [`LevelFilter`](enum.LevelFilter.html).
 #[repr(usize)]
 #[derive(Copy, Eq, Debug, Hash)]
-#[cfg_attr(serde, derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Level {
     /// The "error" level.
     ///
@@ -428,7 +431,7 @@ impl Level {
 /// [`max_level()`](fn.max_level.html).
 #[repr(usize)]
 #[derive(Copy, Eq, Debug, Hash)]
-#[cfg_attr(serde, derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum LevelFilter {
     /// A level lower than all log levels.
     Off,
@@ -1109,6 +1112,8 @@ pub fn __static_max_level() -> LevelFilter {
 #[cfg(test)]
 mod tests {
      extern crate std;
+     #[cfg(feature = "serde")]
+     extern crate serde_json;
      use tests::std::string::ToString;
      use super::{Level, LevelFilter, ParseLevelError};
 
@@ -1202,5 +1207,15 @@ mod tests {
          let e = SetLoggerError(());
          assert_eq!(e.description(), "attempted to set a logger after the logging system \
                      was already initialized");
+     }
+
+     #[test]
+     #[cfg(feature = "serde")]
+     fn test_serde_impls() {
+         let level = Level::Info;
+         let _ = serde_json::to_string(&level).unwrap();
+
+         let level_filter = LevelFilter::Info;
+         let _ = serde_json::to_string(&level_filter).unwrap();
      }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,7 @@ static LEVEL_PARSE_ERROR: &'static str = "attempted to convert a string that doe
 /// [`LevelFilter`](enum.LevelFilter.html).
 #[repr(usize)]
 #[derive(Copy, Eq, Debug, Hash)]
+#[cfg_attr(serde, derive(Serialize, Deserialize))]
 pub enum Level {
     /// The "error" level.
     ///
@@ -427,6 +428,7 @@ impl Level {
 /// [`max_level()`](fn.max_level.html).
 #[repr(usize)]
 #[derive(Copy, Eq, Debug, Hash)]
+#[cfg_attr(serde, derive(Serialize, Deserialize))]
 pub enum LevelFilter {
     /// A level lower than all log levels.
     Off,


### PR DESCRIPTION
Fixes #143 

Adds `serde` as an optional dependency and puts the `Serialize` and `Deserialize` traits behind `cfg_attr`. I wasn't sure what version I should specify. 1.0.7 was the latest when I checked, but maybe it's too specific? Would `>= 1.0` be better?

Saw the post on the internals forum, wanted to help out!