### PR TITLE
Added keywords to log and env_logger Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = """
 A lightweight logging facade for Rust
 """
 categories = ["development-tools::debugging"]
+keywords = ["logging"]
 publish = false # this branch contains breaking changes
 
 [[test]]

--- a/env/Cargo.toml
+++ b/env/Cargo.toml
@@ -11,6 +11,7 @@ A logging implementation for `log` which is configured via an environment
 variable.
 """
 categories = ["development-tools::debugging"]
+keywords = ["logging"]
 publish = false # this branch contains breaking changes
 
 [dependencies]


### PR DESCRIPTION
Hi,
I've added `keywords = ["logger", "log", "logging"]` to both log and env_logger.
These are the best I could came up with.

resolves https://github.com/rust-lang-nursery/log/issues/140