### PR TITLE
Reduce "stuttering" in env_logger symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured
 ## Configuring log target
 
 By default, `env_logger` logs to stderr. If you want to log to stdout instead,
-you can use the `LogBuilder` to change the log target:
+you can use the `Builder` to change the log target:
 
 ```rust
 use std::env;
-use env_logger::{LogBuilder, LogTarget};
+use env_logger::{Builder, Target};
 
-let mut builder = LogBuilder::new();
-builder.target(LogTarget::Stdout);
+let mut builder = Builder::new();
+builder.target(Target::Stdout);
 if env::var("RUST_LOG").is_ok() {
     builder.parse(&env::var("RUST_LOG").unwrap());
 }


### PR DESCRIPTION
I did not know if private symbols `LogDirective` and `parse_logging_spec*` should also be renamed so this PR is split with private symbols in second commit.

Both unit and doct tests pass, hopefully `sed` did not miss anything ;)

resolves: https://github.com/rust-lang-nursery/log/issues/169