### PR TITLE
update html_root_url for env_logger

### DIFF
--- a/env/Cargo.toml
+++ b/env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "env_logger"
-version = "0.4.3"
+version = "0.4.3" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang/log"

--- a/env/src/lib.rs
+++ b/env/src/lib.rs
@@ -127,7 +127,7 @@
 
 #![doc(html_logo_url = "http://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "http://www.rust-lang.org/favicon.ico",
-       html_root_url = "http://doc.rust-lang.org/env_logger/")]
+       html_root_url = "https://docs.rs/env_logger/0.4.3")]
 #![cfg_attr(test, deny(warnings))]
 
 // When compiled for the rustc compiler itself we want to make sure that this is


### PR DESCRIPTION
Closes: #141

@dtolnay there is a `documentation` line in `env/Cargo.toml` here : https://github.com/morrme/log/blob/issue141/env/Cargo.toml#L7  

Should that be updated as well? 