### PR TITLE
Add serde impls for LogLevel/LogLevelFilter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,12 @@ release_max_level_trace = []
 nightly = []
 use_std = []
 default = ["use_std"]
+use_serde = ["serde", "serde_test"]
 
 [badges]
 travis-ci = { repository = "rust-lang-nursery/log" }
 appveyor = { repository = "alexcrichton/log" }
+
+[dependencies]
+serde = {version = "1.0", optional = true }
+serde_test = {version = "1.0", optional = true }


### PR DESCRIPTION
Pull-request for:
https://github.com/rust-lang-nursery/log/issues/143

I am not entirely sure about the format of serialization I have used.
It is also my first contribution, so any feedback is welcome.

To run tests, use:
`cargo test --features "use_serde"`

It misses documentation as of now, but I will add it before merging, I just would like some validation of the code first.