### PR TITLE
Added "Errors" section to set_logger docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -863,6 +863,11 @@ pub fn max_level() -> LevelFilter {
 ///
 /// Requires the `use_std` feature (enabled by default).
 ///
+/// # Errors
+///
+/// This function fails to set the global logger if it has already
+/// been called before.
+///
 /// ## Example
 ///
 /// Implements a custom logger `ConsoleLogger` which prints to stdout.


### PR DESCRIPTION
fixes https://github.com/rust-lang-nursery/log/issues/135