### PR TITLE
Create builders for `Metadata`, `Record`, and `Level`.

### DIFF
--- a/env/src/lib.rs
+++ b/env/src/lib.rs
@@ -215,7 +215,7 @@ impl Builder {
             filter: None,
             format: Box::new(|record: &Record| {
                 format!("{}:{}: {}", record.level(),
-                        record.location().module_path(), record.args())
+                        record.module_path(), record.args())
             }),
             target: Target::Stderr,
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,14 +40,9 @@
 #[macro_export]
 macro_rules! log {
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
-        static _LOC: $crate::Location = $crate::Location {
-            __line: line!(),
-            __file: file!(),
-            __module_path: module_path!(),
-        };
         let lvl = $lvl;
         if lvl <= $crate::__static_max_level() && lvl <= $crate::max_level() {
-            $crate::__log(lvl, $target, &_LOC, format_args!($($arg)+))
+            $crate::__log(lvl, $target, line!(), file!(), module_path!(), format_args!($($arg)+))
         }
     });
     ($lvl:expr, $($arg:tt)+) => (log!(target: module_path!(), $lvl, $($arg)+))


### PR DESCRIPTION
Fixes #116.

Create builders to support the construction of `Metadata`, `Record`, and `Level`. I decided to take `mut self` as the parameter for each builder method because it allows:
```rust
let record = RecordBuilder::new().args(...).metadata(...).build()
```
Whereas taking `&mut self` leads to the temporary object created by `RecordBuilder::new()` being dropped before `build()`.

Not done yet--still need to add examples/docs. Please review everything else!