### PR TITLE
logging levels and corresponding macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,20 @@
 //!
 //! # Use
 //!
+//! The basic use of the log crate is through the five logging macros: [`error!`],   
+//! [`warn!`], [`info!`], [`debug!`] and [`trace!`]  
+//! where `error!` represents the highest-priority log level, and `trace!` the lowest.  
+//!
+//! Each of these macros accept format strings similarly to [`println!`].  
+//! 
+//! 
+//! [`error!`]: ./macro.error.html   
+//! [`warn!`]: ./macro.warn.html  
+//! [`info!`]: ./macro.info.html  
+//! [`debug!`]: ./macro.debug.html   
+//! [`trace!`]: ./macro.trace.html  
+//! [`println!`]: https://doc.rust-lang.org/stable/std/macro.println.html  
+//!
 //! ## In libraries
 //!
 //! Libraries should link only to the `log` crate, and use the provided


### PR DESCRIPTION
As discussed in [issue 121](https://github.com/rust-lang-nursery/log/issues/121),

The logging levels are mentioned in the use section