### PR TITLE
Make __log and __enabled public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,19 +26,19 @@
 //!
 //! # Use
 //!
-//! The basic use of the log crate is through the five logging macros: [`error!`],   
-//! [`warn!`], [`info!`], [`debug!`] and [`trace!`]  
-//! where `error!` represents the highest-priority log level, and `trace!` the lowest.  
+//! The basic use of the log crate is through the five logging macros: [`error!`],
+//! [`warn!`], [`info!`], [`debug!`] and [`trace!`]
+//! where `error!` represents the highest-priority log level, and `trace!` the lowest.
 //!
-//! Each of these macros accept format strings similarly to [`println!`].  
-//! 
-//! 
-//! [`error!`]: ./macro.error.html   
-//! [`warn!`]: ./macro.warn.html  
-//! [`info!`]: ./macro.info.html  
-//! [`debug!`]: ./macro.debug.html   
-//! [`trace!`]: ./macro.trace.html  
-//! [`println!`]: https://doc.rust-lang.org/stable/std/macro.println.html  
+//! Each of these macros accept format strings similarly to [`println!`].
+//!
+//!
+//! [`error!`]: ./macro.error.html
+//! [`warn!`]: ./macro.warn.html
+//! [`info!`]: ./macro.info.html
+//! [`debug!`]: ./macro.debug.html
+//! [`trace!`]: ./macro.trace.html
+//! [`println!`]: https://doc.rust-lang.org/stable/std/macro.println.html
 //!
 //! ## In libraries
 //!
@@ -608,40 +608,49 @@ pub struct Record<'a> {
 
 impl<'a> Record<'a> {
     /// Returns a new builder
+    #[inline]
     pub fn builder() -> RecordBuilder<'a> {
         RecordBuilder::new()
     }
+
     /// The message body.
+    #[inline]
     pub fn args(&self) -> &fmt::Arguments<'a> {
         &self.args
     }
 
     /// Metadata about the log directive.
+    #[inline]
     pub fn metadata(&self) -> &Metadata {
         &self.metadata
     }
 
     /// The verbosity level of the message.
+    #[inline]
     pub fn level(&self) -> Level {
         self.metadata.level()
     }
 
     /// The name of the target of the directive.
+    #[inline]
     pub fn target(&self) -> &str {
         self.metadata.target()
     }
 
     /// The module path of the message.
+    #[inline]
     pub fn module_path(&self) -> &str {
         self.module_path
     }
 
     /// The source file containing the message.
+    #[inline]
     pub fn file(&self) -> &str {
         self.file
     }
 
     /// The line containing the message.
+    #[inline]
     pub fn line(&self) -> u32 {
         self.line
     }
@@ -704,6 +713,7 @@ impl<'a> RecordBuilder<'a> {
     /// - `line`: `0`
     /// [`format_args!("")`]: https://doc.rust-lang.org/std/macro.format_args.html
     /// [`Metadata::builder().build()`]: struct.MetadataBuilder.html#method.build
+    #[inline]
     pub fn new() -> RecordBuilder<'a> {
         RecordBuilder {
             record: Record {
@@ -717,48 +727,56 @@ impl<'a> RecordBuilder<'a> {
     }
 
     /// Set [`args`](struct.Record.html#method.args).
+    #[inline]
     pub fn args(&mut self, args: fmt::Arguments<'a>) -> &mut RecordBuilder<'a> {
         self.record.args = args;
         self
     }
 
     /// Set [`metadata`](struct.Record.html#method.metadata). Construct a `Metadata` object with [`MetadataBuilder`](struct.MetadataBuilder.html).
+    #[inline]
     pub fn metadata(&mut self, metadata: Metadata<'a>) -> &mut RecordBuilder<'a> {
         self.record.metadata = metadata;
         self
     }
 
     /// Set [`Metadata::level`](struct.Metadata.html#method.level).
+    #[inline]
     pub fn level(&mut self, level: Level) -> &mut RecordBuilder<'a> {
         self.record.metadata.level = level;
         self
     }
 
     /// Set [`Metadata::target`](struct.Metadata.html#method.target)
+    #[inline]
     pub fn target(&mut self, target: &'a str) -> &mut RecordBuilder<'a> {
         self.record.metadata.target = target;
         self
     }
 
     /// Set [`module_path`](struct.Record.html#method.module_path)
+    #[inline]
     pub fn module_path(&mut self, path: &'static str) -> &mut RecordBuilder<'a> {
         self.record.module_path = path;
         self
     }
 
     /// Set [`file`](struct.Record.html#method.file)
+    #[inline]
     pub fn file(&mut self, file: &'static str) -> &mut RecordBuilder<'a> {
         self.record.file = file;
         self
     }
 
     /// Set [`line`](struct.Record.html#method.line)
+    #[inline]
     pub fn line(&mut self, line: u32) -> &mut RecordBuilder<'a> {
         self.record.line = line;
         self
     }
 
     /// Invoke the builder and return a `Record`
+    #[inline]
     pub fn build(&self) -> Record<'a> {
         self.record.clone()
     }
@@ -813,16 +831,19 @@ pub struct Metadata<'a> {
 
 impl<'a> Metadata<'a> {
     /// Returns a new builder
+    #[inline]
     pub fn builder() -> MetadataBuilder<'a> {
         MetadataBuilder::new()
     }
 
     /// The verbosity level of the message.
+    #[inline]
     pub fn level(&self) -> Level {
         self.level
     }
 
     /// The name of the target of the directive.
+    #[inline]
     pub fn target(&self) -> &str {
         self.target
     }
@@ -856,6 +877,7 @@ impl<'a> MetadataBuilder<'a> {
     ///
     /// - `level`: `Level::Info`
     /// - `target`: `""`
+    #[inline]
     pub fn new() -> MetadataBuilder<'a> {
         MetadataBuilder {
             metadata: Metadata {
@@ -866,18 +888,21 @@ impl<'a> MetadataBuilder<'a> {
     }
 
     /// Setter for [`level`](struct.Metadata.html#method.level).
+    #[inline]
     pub fn level(&mut self, arg: Level) -> &mut MetadataBuilder<'a> {
         self.metadata.level = arg;
         self
     }
 
     /// Setter for [`target`](struct.Metadata.html#method.target).
+    #[inline]
     pub fn target(&mut self, target: &'a str) -> &mut MetadataBuilder<'a> {
         self.metadata.target = target;
         self
     }
 
     /// Returns a `Metadata` object.
+    #[inline]
     pub fn build(&self) -> Metadata<'a> {
         self.metadata.clone()
     }
@@ -1227,44 +1252,24 @@ fn logger() -> Option<&'static Log> {
     }
 }
 
-// WARNING
-// This is not considered part of the crate's public API. It is subject to
-// change at any time.
-#[doc(hidden)]
-pub fn __enabled(level: Level, target: &str) -> bool {
+/// Determines if `Record`s with the provided metadata would be logged or not.
+///
+/// This can be used to avoid expensive computation of log data that would just
+/// be discarded. It is called by the `log_enabled!()` macro.
+pub fn enabled(metadata: &Metadata) -> bool {
     if let Some(logger) = logger() {
-        logger.enabled(&Metadata {
-                           level: level,
-                           target: target,
-                       })
+        logger.enabled(metadata)
     } else {
         false
     }
 }
 
-// WARNING
-// This is not considered part of the crate's public API. It is subject to
-// change at any time.
-#[doc(hidden)]
-pub fn __log(level: Level,
-    target: &str,
-    line: u32,
-    file: &'static str,
-    module_path: &'static str,
-    args: fmt::Arguments
-) {
+/// Logs the `Record` with the registered logger.
+///
+/// It is called by the `log!`, `error!`, `warn!`, etc macros.
+pub fn log(record: &Record) {
     if let Some(logger) = logger() {
-        let record = Record {
-            metadata: Metadata {
-                level: level,
-                target: target,
-            },
-            args: args,
-            line: line,
-            file: file,
-            module_path: module_path,
-        };
-        logger.log(&record)
+        logger.log(record)
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,7 +42,16 @@ macro_rules! log {
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::__static_max_level() && lvl <= $crate::max_level() {
-            $crate::__log(lvl, $target, line!(), file!(), module_path!(), format_args!($($arg)+))
+            $crate::log(
+                &$crate::RecordBuilder::new()
+                    .args(format_args!($($arg)+))
+                    .level(lvl)
+                    .target($target)
+                    .module_path(module_path!())
+                    .file(file!())
+                    .line(line!())
+                    .build()
+            )
         }
     });
     ($lvl:expr, $($arg:tt)+) => (log!(target: module_path!(), $lvl, $($arg)+))
@@ -242,7 +251,12 @@ macro_rules! log_enabled {
     (target: $target:expr, $lvl:expr) => ({
         let lvl = $lvl;
         lvl <= $crate::__static_max_level() && lvl <= $crate::max_level() &&
-            $crate::__enabled(lvl, $target)
+            $crate::enabled(
+                &$crate::MetadataBuilder::new()
+                    .level(lvl)
+                    .target($target)
+                    .build(),
+            )
     });
     ($lvl:expr) => (log_enabled!(target: module_path!(), $lvl))
 }


### PR DESCRIPTION
They now take a `&Record` and `&Metadata` respectively. Shim libraries
from other logging frameworks will want to construct these types
directly rather than using the log macros.

r? @alexcrichton 

Disassembly of --release optimized

```rust
#[macro_use]
extern crate log;

fn main() {
    debug!("hello world!");
}
```

Before:

```asm
00000000000068b0 <_ZN3foo4main17h1780161ba875bb72E>:
    68b0:       48 83 ec 38             sub    $0x38,%rsp
    68b4:       48 8d 05 75 7b 24 00    lea    0x247b75(%rip),%rax        # 24e430 <_ZN3log20MAX_LOG_LEVEL_FILTER17h69a143a1bb28dbc7E>                                                                                                                 
    68bb:       48 8b 00                mov    (%rax),%rax                                                                                                                                                                                             
    68be:       31 c9                   xor    %ecx,%ecx                                                                                                                                                                                               
    68c0:       48 83 f8 04             cmp    $0x4,%rax                                                                                                                                                                                               
    68c4:       b8 01 00 00 00          mov    $0x1,%eax                                                                                                                                                                                               
    68c9:       48 c7 c2 ff ff ff ff    mov    $0xffffffffffffffff,%rdx                                                                                                                                                                                
    68d0:       48 0f 46 d0             cmovbe %rax,%rdx                                                                                                                                                                                               
    68d4:       48 0f 45 ca             cmovne %rdx,%rcx                                                                                                                                                                                               
    68d8:       48 ff c1                inc    %rcx                                                                                                                                                                                                    
    68db:       48 83 f9 01             cmp    $0x1,%rcx                                                                                                                                                                                               
    68df:       77 6c                   ja     694d <_ZN3foo4main17h1780161ba875bb72E+0x9d>                                                                                                                                                            
    68e1:       48 8d 05 e8 5f 24 00    lea    0x245fe8(%rip),%rax        # 24c8d0 <ref.4>                                                                                                                                                             
    68e8:       48 89 44 24 08          mov    %rax,0x8(%rsp)                                                                                                                                                                                          
    68ed:       48 c7 44 24 10 01 00    movq   $0x1,0x10(%rsp)                                                                                                                                                                                         
    68f4:       00 00                                                                                                                                                                                                                                  
    68f6:       48 c7 44 24 18 00 00    movq   $0x0,0x18(%rsp)                                                                                                                                                                                         
    68fd:       00 00                                                                                                                                                                                                                                  
    68ff:       48 8d 05 02 24 03 00    lea    0x32402(%rip),%rax        # 38d08 <str.2>                                                                                                                                                               
    6906:       48 89 44 24 28          mov    %rax,0x28(%rsp)                                                                                                                                                                                         
    690b:       48 c7 44 24 30 00 00    movq   $0x0,0x30(%rsp)                                                                                                                                                                                         
    6912:       00 00                                                                                                                                                                                                                                  
    6914:       48 83 ec 08             sub    $0x8,%rsp                                                                                                                                                                                               
    6918:       48 8d 44 24 10          lea    0x10(%rsp),%rax                                                                                                                                                                                         
    691d:       48 8d 35 dc 23 03 00    lea    0x323dc(%rip),%rsi        # 38d00 <str.0>                                                                                                                                                               
    6924:       4c 8d 05 dd 23 03 00    lea    0x323dd(%rip),%r8        # 38d08 <str.2>                                                                                                                                                                
    692b:       bf 04 00 00 00          mov    $0x4,%edi                                                                                                                                                                                               
    6930:       ba 03 00 00 00          mov    $0x3,%edx                                                                                                                                                                                               
    6935:       b9 05 00 00 00          mov    $0x5,%ecx                                                                                                                                                                                               
    693a:       41 b9 0f 00 00 00       mov    $0xf,%r9d                                                                                                                                                                                               
    6940:       50                      push   %rax                                                                                                                                                                                                    
    6941:       6a 03                   pushq  $0x3                                                                                                                                                                                                    
    6943:       56                      push   %rsi                                                                                                                                                                                                    
    6944:       e8 77 00 00 00          callq  69c0 <_ZN3log5__log17ha34c7c983d25ce1cE>                                                                                                                                                                
    6949:       48 83 c4 20             add    $0x20,%rsp                                                                                                                                                                                              
    694d:       48 83 c4 38             add    $0x38,%rsp                                                                                                                                                                                              
    6951:       c3                      retq                                                                                                                                                                                                           
    6952:       66 2e 0f 1f 84 00 00    nopw   %cs:0x0(%rax,%rax,1)                                                                                                                                                                                    
    6959:       00 00 00                                                                                                                                                                                                                               
    695c:       0f 1f 40 00             nopl   0x0(%rax)
```

After:

```asm
00000000000068b0 <_ZN3foo4main17h1780161ba875bb72E>:
    68b0:       48 83 ec 78             sub    $0x78,%rsp
    68b4:       48 8d 05 75 6b 24 00    lea    0x246b75(%rip),%rax        # 24d430 <_ZN3log20MAX_LOG_LEVEL_FILTER17h69a143a1bb28dbc7E>                                                                                                                 
    68bb:       48 8b 00                mov    (%rax),%rax                                                                                                                                                                                             
    68be:       31 c9                   xor    %ecx,%ecx                                                                                                                                                                                               
    68c0:       48 83 f8 04             cmp    $0x4,%rax                                                                                                                                                                                               
    68c4:       b8 01 00 00 00          mov    $0x1,%eax                                                                                                                                                                                               
    68c9:       48 c7 c2 ff ff ff ff    mov    $0xffffffffffffffff,%rdx                                                                                                                                                                                
    68d0:       48 0f 46 d0             cmovbe %rax,%rdx                                                                                                                                                                                               
    68d4:       48 0f 45 ca             cmovne %rdx,%rcx                                                                                                                                                                                               
    68d8:       48 ff c1                inc    %rcx                                                                                                                                                                                                    
    68db:       48 83 f9 01             cmp    $0x1,%rcx                                                                                                                                                                                               
    68df:       0f 87 9b 00 00 00       ja     6980 <_ZN3foo4main17h1780161ba875bb72E+0xd0>                                                                                                                                                            
    68e5:       b8 04 00 00 00          mov    $0x4,%eax                                                                                                                                                                                               
    68ea:       66 48 0f 6e c0          movq   %rax,%xmm0                                                                                                                                                                                              
    68ef:       48 8d 05 8a 23 03 00    lea    0x3238a(%rip),%rax        # 38c80 <str.2>                                                                                                                                                               
    68f6:       66 48 0f 6e c8          movq   %rax,%xmm1                                                                                                                                                                                              
    68fb:       66 0f 6c c1             punpcklqdq %xmm1,%xmm0                                                                                                                                                                                         
    68ff:       66 0f 7f 04 24          movdqa %xmm0,(%rsp)                                                                                                                                                                                            
    6904:       48 8d 05 c5 4f 24 00    lea    0x244fc5(%rip),%rax        # 24b8d0 <ref.5>                                                                                                                                                             
    690b:       66 48 0f 6e c0          movq   %rax,%xmm0                                                                                                                                                                                              
    6910:       b8 03 00 00 00          mov    $0x3,%eax                                                                                                                                                                                               
    6915:       66 48 0f 6e d0          movq   %rax,%xmm2                                                                                                                                                                                              
    691a:       66 0f 6f da             movdqa %xmm2,%xmm3                                                                                                                                                                                             
    691e:       66 0f 6c d8             punpcklqdq %xmm0,%xmm3                                                                                                                                                                                         
    6922:       66 0f 7f 5c 24 10       movdqa %xmm3,0x10(%rsp)                                                                                                                                                                                        
    6928:       48 c7 44 24 20 01 00    movq   $0x1,0x20(%rsp)                                                                                                                                                                                         
    692f:       00 00                                                                                                                                                                                                                                  
    6931:       48 c7 44 24 28 00 00    movq   $0x0,0x28(%rsp)                                                                                                                                                                                         
    6938:       00 00                                                                                                                                                                                                                                  
    693a:       48 8d 05 3f 23 03 00    lea    0x3233f(%rip),%rax        # 38c80 <str.2>                                                                                                                                                               
    6941:       48 89 44 24 38          mov    %rax,0x38(%rsp)                                                                                                                                                                                         
    6946:       66 0f 73 f9 08          pslldq $0x8,%xmm1                                                                                                                                                                                              
    694b:       66 0f 7f 4c 24 40       movdqa %xmm1,0x40(%rsp)                                                                                                                                                                                        
    6951:       48 8d 05 2b 23 03 00    lea    0x3232b(%rip),%rax        # 38c83 <str.3>                                                                                                                                                               
    6958:       66 48 0f 6e c0          movq   %rax,%xmm0                                                                                                                                                                                              
    695d:       66 0f 6c d0             punpcklqdq %xmm0,%xmm2                                                                                                                                                                                         
    6961:       66 0f 7f 54 24 50       movdqa %xmm2,0x50(%rsp)                                                                                                                                                                                        
    6967:       48 c7 44 24 60 0f 00    movq   $0xf,0x60(%rsp)                                                                                                                                                                                         
    696e:       00 00                                                                                                                                                                                                                                  
    6970:       c7 44 24 68 05 00 00    movl   $0x5,0x68(%rsp)                                                                                                                                                                                         
    6977:       00                                                                                                                                                                                                                                     
    6978:       48 89 e7                mov    %rsp,%rdi                                                                                                                                                                                               
    697b:       e8 70 00 00 00          callq  69f0 <_ZN3log3log17h983b2da753f78141E>                                                                                                                                                                  
    6980:       48 83 c4 78             add    $0x78,%rsp                                                                                                                                                                                              
    6984:       c3                      retq                                                                                                                                                                                                           
    6985:       66 2e 0f 1f 84 00 00    nopw   %cs:0x0(%rax,%rax,1)                                                                                                                                                                                    
    698c:       00 00 00                                                                                                                                                                                                                               
    698f:       90                      nop
```