### PR TITLE
Replace log and enabled functions with logger

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,7 +42,8 @@ macro_rules! log {
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
-            $crate::log(
+            $crate::Log::log(
+                $crate::logger(),
                 &$crate::RecordBuilder::new()
                     .args(format_args!($($arg)+))
                     .level(lvl)
@@ -251,7 +252,8 @@ macro_rules! log_enabled {
     (target: $target:expr, $lvl:expr) => ({
         let lvl = $lvl;
         lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() &&
-            $crate::enabled(
+            $crate::Log::enabled(
+                $crate::logger(),
                 &$crate::MetadataBuilder::new()
                     .level(lvl)
                     .target($target)


### PR DESCRIPTION
We also have flush on the Log trait, and at that point it makes more
sense to just return the logger directly.

r? @alexcrichton 