### PR TITLE
[env_logger] Adds a newline to format string before writing

### DIFF
--- a/env/src/lib.rs
+++ b/env/src/lib.rs
@@ -371,7 +371,8 @@ impl Log for Logger {
         match self.target {
             Target::Stdout => println!("{}", (self.format)(record)),
             Target::Stderr => {
-                let _ = writeln!(&mut io::stderr(), "{}", (self.format)(record));
+                let value = (self.format)(record) + "\n";
+                let _ = io::stderr().write_all(value.as_bytes());
             },
         };
     }


### PR DESCRIPTION
This is important so in unix systems most of the time buffer is output
atomically (until certain length of message). Which means you don't get
two lines squashed together if they are written simultaneously.

I believe most of the time it's doesn't influence performance, because
underlying buffer of string is probably overallocated a bit anyway.