### PR TITLE
Allow `#[macro_use(info)]` to import individual macros.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ publish = false # this branch contains breaking changes
 name = "filters"
 harness = false
 
+[[test]]
+name = "macro_use"
+
 [features]
 max_level_off   = []
 max_level_error = []

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -41,6 +41,9 @@
 macro_rules! log {
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
+        // Warning: This code is duplicated in `log!`/`error!`/`warn!`/... -
+        // see discussion in #54. Once rust-lang/rust#25003 is fixed, this may
+        // no longer be necessary.
         if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
             $crate::Log::log(
                 $crate::logger(),
@@ -77,10 +80,24 @@ macro_rules! log {
 #[macro_export]
 macro_rules! error {
     (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Error, $($arg)*);
+        let lvl = $crate::Level::Error;
+        // Warning: This code is duplicated in `log!`/`error!`/`warn!`/...
+        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+            $crate::Log::log(
+                $crate::logger(),
+                &$crate::RecordBuilder::new()
+                    .args(format_args!($($arg)+))
+                    .level(lvl)
+                    .target($target)
+                    .module_path(module_path!())
+                    .file(file!())
+                    .line(line!())
+                    .build()
+            )
+        }
     );
     ($($arg:tt)*) => (
-        log!($crate::Level::Error, $($arg)*);
+        error!(target: module_path!(), $($arg)*);
     )
 }
 
@@ -108,10 +125,24 @@ macro_rules! error {
 #[macro_export]
 macro_rules! warn {
     (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Warn, $($arg)*);
+        let lvl = $crate::Level::Warn;
+        // Warning: This code is duplicated in `log!`/`error!`/`warn!`/...
+        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+            $crate::Log::log(
+                $crate::logger(),
+                &$crate::RecordBuilder::new()
+                    .args(format_args!($($arg)+))
+                    .level(lvl)
+                    .target($target)
+                    .module_path(module_path!())
+                    .file(file!())
+                    .line(line!())
+                    .build()
+            )
+        }
     );
     ($($arg:tt)*) => (
-        log!($crate::Level::Warn, $($arg)*);
+        warn!(target: module_path!(), $($arg)*);
     )
 }
 
@@ -142,10 +173,24 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! info {
     (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Info, $($arg)*);
+        let lvl = $crate::Level::Info;
+        // Warning: This code is duplicated in `log!`/`error!`/`warn!`/...
+        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+            $crate::Log::log(
+                $crate::logger(),
+                &$crate::RecordBuilder::new()
+                    .args(format_args!($($arg)+))
+                    .level(lvl)
+                    .target($target)
+                    .module_path(module_path!())
+                    .file(file!())
+                    .line(line!())
+                    .build()
+            )
+        }
     );
     ($($arg:tt)*) => (
-        log!($crate::Level::Info, $($arg)*);
+        info!(target: module_path!(), $($arg)*);
     )
 }
 
@@ -176,10 +221,24 @@ macro_rules! info {
 #[macro_export]
 macro_rules! debug {
     (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Debug, $($arg)*);
+        let lvl = $crate::Level::Debug;
+        // Warning: This code is duplicated in `log!`/`error!`/`warn!`/...
+        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+            $crate::Log::log(
+                $crate::logger(),
+                &$crate::RecordBuilder::new()
+                    .args(format_args!($($arg)+))
+                    .level(lvl)
+                    .target($target)
+                    .module_path(module_path!())
+                    .file(file!())
+                    .line(line!())
+                    .build()
+            )
+        }
     );
     ($($arg:tt)*) => (
-        log!($crate::Level::Debug, $($arg)*);
+        debug!(target: module_path!(), $($arg)*);
     )
 }
 
@@ -213,10 +272,24 @@ macro_rules! debug {
 #[macro_export]
 macro_rules! trace {
     (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Trace, $($arg)*);
+        let lvl = $crate::Level::Trace;
+        // Warning: This code is duplicated in `log!`/`error!`/`warn!`/...
+        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+            $crate::Log::log(
+                $crate::logger(),
+                &$crate::RecordBuilder::new()
+                    .args(format_args!($($arg)+))
+                    .level(lvl)
+                    .target($target)
+                    .module_path(module_path!())
+                    .file(file!())
+                    .line(line!())
+                    .build()
+            )
+        }
     );
     ($($arg:tt)*) => (
-        log!($crate::Level::Trace, $($arg)*);
+        trace!(target: module_path!(), $($arg)*);
     )
 }
 

--- a/tests/macro_use.rs
+++ b/tests/macro_use.rs
@@ -1,0 +1,9 @@
+//! Ensures individual macros can be used - see #54.
+
+#[macro_use(info)]
+extern crate log;
+
+#[test]
+fn can_import_and_use_just_info() {
+    info!("doesn't matter");
+}


### PR DESCRIPTION
Inline logic from `log!` into `error!`/`warn!`/`...`.

Alternatively, we could create a helper function which all macros call (passing in the output of `file!`/`line!`/etc.), but this helper function would need to be in the public API of `log`, which is a bit ugly.

After playing around with alternatives, I figured I may as well open a PR for this option (which I consider to be the least of all evils). If the duplication is undesirable, then feel free to close! :)

Fixes #54.