### PR TITLE
Restructure initialization setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ rust:
   - stable
   - beta
   - nightly
-before_script:
-  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo build --verbose
   - cargo build --verbose --features serde
@@ -15,11 +13,6 @@ script:
   - cargo test --verbose --features use_std
   - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml
   - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml --release
-after_success:
-  - travis-cargo --only nightly doc-upload
-env:
-  global:
-    secure: "VPHgnszydMudYTY8cthHj/Dmxqp7OmTiu4Sa/705Udsx+tYblTv+8WdThkClo3C/asStVcxlaRWAp91UX32/k4SfkPz17XId3Wadyt03r73ANm6ZOWY+qty+3/LINm54kuTxYUDDTbD6NaFNPFQLIE0xCpJeiXUQTlaMk6z0W3M="
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ before_script:
 script:
   - cargo build --verbose
   - cargo build --verbose --features serde
-  - cargo build --verbose --no-default-features
+  - cargo build --verbose --features use_std
   - cargo test --verbose
   - cargo test --verbose --features serde
-  - cargo test --verbose --no-default-features
+  - cargo test --verbose --features use_std
   - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml
   - cargo run --verbose --manifest-path tests/max_level_features/Cargo.toml --release
 after_success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ release_max_level_debug = []
 release_max_level_trace = []
 
 use_std = []
-default = ["use_std"]
 
 [badges]
 travis-ci = { repository = "rust-lang-nursery/log" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["development-tools::debugging"]
 keywords = ["logging"]
 publish = false # this branch contains breaking changes
 
+[package.metadata.docs.rs]
+features = ["use_std"]
+
 [[test]]
 name = "filters"
 harness = false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,3 +16,4 @@ build: false
 test_script:
   - cargo test --verbose
   - cargo test --verbose --features serde
+  - cargo test --verbose --features use_std

--- a/tests/max_level_features/main.rs
+++ b/tests/max_level_features/main.rs
@@ -6,12 +6,12 @@ use log::{Level, LevelFilter, Log, Record, Metadata};
 use log::MaxLevelFilter;
 
 #[cfg(feature = "use_std")]
-use log::try_set_logger;
+use log::set_boxed_logger;
 #[cfg(not(feature = "use_std"))]
-fn try_set_logger<M>(make_logger: M) -> Result<(), log::SetLoggerError>
+fn set_boxed_logger<M>(make_logger: M) -> Result<(), log::SetLoggerError>
     where M: FnOnce(MaxLevelFilter) -> Box<Log> {
     unsafe {
-        log::try_set_logger_raw(|x| std::mem::transmute(make_logger(x)))
+        log::set_logger(|x| &*Box::into_raw(make_logger(x)))
     }
 }
 
@@ -36,7 +36,7 @@ impl Log for Logger {
 
 fn main() {
     let mut a = None;
-    try_set_logger(|max| {
+    set_boxed_logger(|max| {
         let me = Arc::new(State {
             last_log: Mutex::new(None),
             filter: max,


### PR DESCRIPTION
try_set_logger_raw is now set_logger and try_set_logger is now
set_boxed_logger. The use_std feature is now disabled by default. The
old set_logger has been removed.

When we did the crate evaluation for log, we wanted to add more variants
of set_logger that e.g. panicked by default, but I'm no longer convinced
that's a good idea. There are going to be very few instances of actually
calling these methods explicitly, since each logger implementation
should be providing their own init method that calls them. Having a huge
constellation of functions that all do basically the same thing just
makes things really confusing. We also don't want to encourage logger
implementations to only provide an init function that panics because a
common way of working with logging in tests is to try to init the system
in each test and ignore the result.

r? @alexcrichton 