### PR TITLE
Remove static log config info from macro docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,9 +397,9 @@ fn eq_ignore_ascii_case(a: &str, b: &str) -> bool {
     }
 
     if a.len() == b.len() {
-        a.bytes()
-            .zip(b.bytes())
-            .all(|(a, b)| to_ascii_uppercase(a) == to_ascii_uppercase(b))
+        a.bytes().zip(b.bytes()).all(|(a, b)| {
+            to_ascii_uppercase(a) == to_ascii_uppercase(b)
+        })
     } else {
         false
     }
@@ -408,14 +408,16 @@ fn eq_ignore_ascii_case(a: &str, b: &str) -> bool {
 impl FromStr for Level {
     type Err = ParseLevelError;
     fn from_str(level: &str) -> Result<Level, Self::Err> {
-        ok_or(LOG_LEVEL_NAMES
-                  .iter()
-                  .position(|&name| eq_ignore_ascii_case(name, level))
-                  .into_iter()
-                  .filter(|&idx| idx != 0)
-                  .map(|idx| Level::from_usize(idx).unwrap())
-                  .next(),
-              ParseLevelError(()))
+        ok_or(
+            LOG_LEVEL_NAMES
+                .iter()
+                .position(|&name| eq_ignore_ascii_case(name, level))
+                .into_iter()
+                .filter(|&idx| idx != 0)
+                .map(|idx| Level::from_usize(idx).unwrap())
+                .next(),
+            ParseLevelError(()),
+        )
     }
 }
 
@@ -521,11 +523,13 @@ impl Ord for LevelFilter {
 impl FromStr for LevelFilter {
     type Err = ParseLevelError;
     fn from_str(level: &str) -> Result<LevelFilter, Self::Err> {
-        ok_or(LOG_LEVEL_NAMES
-                  .iter()
-                  .position(|&name| eq_ignore_ascii_case(name, level))
-                  .map(|p| LevelFilter::from_usize(p).unwrap()),
-              ParseLevelError(()))
+        ok_or(
+            LOG_LEVEL_NAMES
+                .iter()
+                .position(|&name| eq_ignore_ascii_case(name, level))
+                .map(|p| LevelFilter::from_usize(p).unwrap()),
+            ParseLevelError(()),
+        )
     }
 }
 
@@ -706,10 +710,9 @@ impl<'a> Record<'a> {
 ///                 .module_path("server")
 ///                 .build();
 /// ```
-
 #[derive(Debug)]
 pub struct RecordBuilder<'a> {
-    record: Record<'a>
+    record: Record<'a>,
 }
 
 impl<'a> RecordBuilder<'a> {
@@ -733,7 +736,7 @@ impl<'a> RecordBuilder<'a> {
                 module_path: "",
                 file: "",
                 line: 0,
-            }
+            },
         }
     }
 
@@ -878,7 +881,7 @@ impl<'a> Metadata<'a> {
 /// ```
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct MetadataBuilder<'a> {
-    metadata: Metadata<'a>
+    metadata: Metadata<'a>,
 }
 
 impl<'a> MetadataBuilder<'a> {
@@ -894,7 +897,7 @@ impl<'a> MetadataBuilder<'a> {
             metadata: Metadata {
                 level: Level::Info,
                 target: "",
-            }
+            },
         }
     }
 
@@ -1014,7 +1017,8 @@ pub fn max_level() -> LevelFilter {
 /// [`set_logger`]: fn.set_logger.html
 #[cfg(feature = "std")]
 pub fn set_boxed_logger<M>(make_logger: M) -> Result<(), SetLoggerError>
-    where M: FnOnce(MaxLevelFilter) -> Box<Log>
+where
+    M: FnOnce(MaxLevelFilter) -> Box<Log>,
 {
     unsafe { set_logger(|max_level| &*Box::into_raw(make_logger(max_level))) }
 }
@@ -1073,7 +1077,8 @@ pub fn set_boxed_logger<M>(make_logger: M) -> Result<(), SetLoggerError>
 /// # }
 /// ```
 pub fn set_logger<M>(make_logger: M) -> Result<(), SetLoggerError>
-    where M: FnOnce(MaxLevelFilter) -> &'static Log
+where
+    M: FnOnce(MaxLevelFilter) -> &'static Log,
 {
     unsafe {
         if STATE.compare_and_swap(UNINITIALIZED, INITIALIZING, Ordering::SeqCst) != UNINITIALIZED {
@@ -1187,19 +1192,21 @@ mod tests {
 
     #[test]
     fn test_levelfilter_from_str() {
-        let tests = [("off", Ok(LevelFilter::Off)),
-                     ("error", Ok(LevelFilter::Error)),
-                     ("warn", Ok(LevelFilter::Warn)),
-                     ("info", Ok(LevelFilter::Info)),
-                     ("debug", Ok(LevelFilter::Debug)),
-                     ("trace", Ok(LevelFilter::Trace)),
-                     ("OFF", Ok(LevelFilter::Off)),
-                     ("ERROR", Ok(LevelFilter::Error)),
-                     ("WARN", Ok(LevelFilter::Warn)),
-                     ("INFO", Ok(LevelFilter::Info)),
-                     ("DEBUG", Ok(LevelFilter::Debug)),
-                     ("TRACE", Ok(LevelFilter::Trace)),
-                     ("asdf", Err(ParseLevelError(())))];
+        let tests = [
+            ("off", Ok(LevelFilter::Off)),
+            ("error", Ok(LevelFilter::Error)),
+            ("warn", Ok(LevelFilter::Warn)),
+            ("info", Ok(LevelFilter::Info)),
+            ("debug", Ok(LevelFilter::Debug)),
+            ("trace", Ok(LevelFilter::Trace)),
+            ("OFF", Ok(LevelFilter::Off)),
+            ("ERROR", Ok(LevelFilter::Error)),
+            ("WARN", Ok(LevelFilter::Warn)),
+            ("INFO", Ok(LevelFilter::Info)),
+            ("DEBUG", Ok(LevelFilter::Debug)),
+            ("TRACE", Ok(LevelFilter::Trace)),
+            ("asdf", Err(ParseLevelError(()))),
+        ];
         for &(s, ref expected) in &tests {
             assert_eq!(expected, &s.parse());
         }
@@ -1207,18 +1214,20 @@ mod tests {
 
     #[test]
     fn test_level_from_str() {
-        let tests = [("OFF", Err(ParseLevelError(()))),
-                     ("error", Ok(Level::Error)),
-                     ("warn", Ok(Level::Warn)),
-                     ("info", Ok(Level::Info)),
-                     ("debug", Ok(Level::Debug)),
-                     ("trace", Ok(Level::Trace)),
-                     ("ERROR", Ok(Level::Error)),
-                     ("WARN", Ok(Level::Warn)),
-                     ("INFO", Ok(Level::Info)),
-                     ("DEBUG", Ok(Level::Debug)),
-                     ("TRACE", Ok(Level::Trace)),
-                     ("asdf", Err(ParseLevelError(())))];
+        let tests = [
+            ("OFF", Err(ParseLevelError(()))),
+            ("error", Ok(Level::Error)),
+            ("warn", Ok(Level::Warn)),
+            ("info", Ok(Level::Info)),
+            ("debug", Ok(Level::Debug)),
+            ("trace", Ok(Level::Trace)),
+            ("ERROR", Ok(Level::Error)),
+            ("WARN", Ok(Level::Warn)),
+            ("INFO", Ok(Level::Info)),
+            ("DEBUG", Ok(Level::Debug)),
+            ("TRACE", Ok(Level::Trace)),
+            ("asdf", Err(ParseLevelError(()))),
+        ];
         for &(s, ref expected) in &tests {
             assert_eq!(expected, &s.parse());
         }
@@ -1269,9 +1278,11 @@ mod tests {
         use std::error::Error;
         use super::SetLoggerError;
         let e = SetLoggerError(());
-        assert_eq!(e.description(),
-                   "attempted to set a logger after the logging system \
-                     was already initialized");
+        assert_eq!(
+            e.description(),
+            "attempted to set a logger after the logging system \
+                     was already initialized"
+        );
     }
 
     #[test]
@@ -1279,9 +1290,9 @@ mod tests {
         use super::MetadataBuilder;
         let target = "myApp";
         let metadata_test = MetadataBuilder::new()
-                            .level(Level::Debug)
-                            .target(target)
-                            .build();
+            .level(Level::Debug)
+            .target(target)
+            .build();
         assert_eq!(metadata_test.level(), Level::Debug);
         assert_eq!(metadata_test.target(), "myApp");
     }
@@ -1291,9 +1302,9 @@ mod tests {
         use super::Metadata;
         let target = "myApp";
         let metadata_test = Metadata::builder()
-                            .level(Level::Debug)
-                            .target(target)
-                            .build();
+            .level(Level::Debug)
+            .target(target)
+            .build();
         assert_eq!(metadata_test.level(), Level::Debug);
         assert_eq!(metadata_test.target(), "myApp");
     }
@@ -1302,17 +1313,15 @@ mod tests {
     fn test_record_builder() {
         use super::{MetadataBuilder, RecordBuilder};
         let target = "myApp";
-        let metadata = MetadataBuilder::new()
-                        .target(target)
-                        .build();
+        let metadata = MetadataBuilder::new().target(target).build();
         let fmt_args = format_args!("hello");
         let record_test = RecordBuilder::new()
-                            .args(fmt_args)
-                            .metadata(metadata)
-                            .module_path("foo")
-                            .file("bar")
-                            .line(30)
-                            .build();
+            .args(fmt_args)
+            .metadata(metadata)
+            .module_path("foo")
+            .file("bar")
+            .line(30)
+            .build();
         assert_eq!(record_test.metadata().target(), "myApp");
         assert_eq!(record_test.module_path(), "foo");
         assert_eq!(record_test.file(), "bar");
@@ -1323,17 +1332,15 @@ mod tests {
     fn test_record_convenience_builder() {
         use super::{Metadata, Record};
         let target = "myApp";
-        let metadata = Metadata::builder()
-                        .target(target)
-                        .build();
+        let metadata = Metadata::builder().target(target).build();
         let fmt_args = format_args!("hello");
         let record_test = Record::builder()
-                            .args(fmt_args)
-                            .metadata(metadata)
-                            .module_path("foo")
-                            .file("bar")
-                            .line(30)
-                            .build();
+            .args(fmt_args)
+            .metadata(metadata)
+            .module_path("foo")
+            .file("bar")
+            .line(30)
+            .build();
         assert_eq!(record_test.target(), "myApp");
         assert_eq!(record_test.module_path(), "foo");
         assert_eq!(record_test.file(), "bar");

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -7,19 +7,11 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+
 /// The standard logging macro.
 ///
 /// This macro will generically log with the specified `Level` and `format!`
 /// based argument list.
-///
-/// The `max_level_*` build features can be used to statically disable logging at
-/// various levels. For instance, `max_level_error` disables log messages below `Error`,
-/// `max_level_info` allows for `Error`, `Warn` and `Info` while `max_level_off` disables logging all together.
-///
-/// When building in release mode (i.e., without the `debug_assertions` option),
-/// the additional `release_max_level_*` build features with identical semantics take precedence.
-/// For instance, `release_max_level_debug` allows for all messages except for `Trace`
-/// while `release_max_level_trace` allows for all messages of logging levels.
 ///
 /// # Examples
 ///
@@ -60,8 +52,6 @@ macro_rules! log {
 
 /// Logs a message at the error level.
 ///
-/// Logging at this level is disabled if the `max_level_off` feature is present.
-///
 /// # Examples
 ///
 /// ```rust
@@ -86,13 +76,6 @@ macro_rules! error {
 
 /// Logs a message at the warn level.
 ///
-/// Logging at this level is disabled if any of the following features are
-/// present: `max_level_off` or `max_level_error`.
-///
-/// When building in release mode (i.e., without the `debug_assertions` option),
-/// logging at this level is also disabled if any of the following features are
-/// present: `release_max_level_off` or `max_level_error`.
-///
 /// # Examples
 ///
 /// ```rust
@@ -116,14 +99,6 @@ macro_rules! warn {
 }
 
 /// Logs a message at the info level.
-///
-/// Logging at this level is disabled if any of the following features are
-/// present: `max_level_off`, `max_level_error`, or `max_level_warn`.
-///
-/// When building in release mode (i.e., without the `debug_assertions` option),
-/// logging at this level is also disabled if any of the following features are
-/// present: `release_max_level_off`, `release_max_level_error`, or
-/// `release_max_level_warn`.
 ///
 /// # Examples
 ///
@@ -151,15 +126,6 @@ macro_rules! info {
 
 /// Logs a message at the debug level.
 ///
-/// Logging at this level is disabled if any of the following features are
-/// present: `max_level_off`, `max_level_error`, `max_level_warn`, or
-/// `max_level_info`.
-///
-/// When building in release mode (i.e., without the `debug_assertions` option),
-/// logging at this level is also disabled if any of the following features are
-/// present: `release_max_level_off`, `release_max_level_error`,
-/// `release_max_level_warn`, or `release_max_level_info`.
-///
 /// # Examples
 ///
 /// ```rust
@@ -184,16 +150,6 @@ macro_rules! debug {
 }
 
 /// Logs a message at the trace level.
-///
-/// Logging at this level is disabled if any of the following features are
-/// present: `max_level_off`, `max_level_error`, `max_level_warn`,
-/// `max_level_info`, or `max_level_debug`.
-///
-/// When building in release mode (i.e., without the `debug_assertions` option),
-/// logging at this level is also disabled if any of the following features are
-/// present: `release_max_level_off`, `release_max_level_error`,
-/// `release_max_level_warn`, `release_max_level_info`, or
-/// `release_max_level_debug`.
 ///
 /// # Examples
 ///

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -14,7 +14,8 @@ use std::str::FromStr;
 
 impl Serialize for Level {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         match *self {
             Level::Error => serializer.serialize_unit_variant("Level", 0, "ERROR"),
@@ -28,7 +29,8 @@ impl Serialize for Level {
 
 impl<'de> Deserialize<'de> for Level {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         struct LevelIdentifier;
 
@@ -40,7 +42,8 @@ impl<'de> Deserialize<'de> for Level {
             }
 
             fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-                where E: Error
+            where
+                E: Error,
             {
                 // Case insensitive.
                 FromStr::from_str(s).map_err(|_| Error::unknown_variant(s, &LOG_LEVEL_NAMES[1..]))
@@ -51,7 +54,8 @@ impl<'de> Deserialize<'de> for Level {
             type Value = Level;
 
             fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-                where D: Deserializer<'de>
+            where
+                D: Deserializer<'de>,
             {
                 deserializer.deserialize_identifier(LevelIdentifier)
             }
@@ -67,7 +71,8 @@ impl<'de> Deserialize<'de> for Level {
             }
 
             fn visit_enum<A>(self, value: A) -> Result<Self::Value, A::Error>
-                where A: EnumAccess<'de>
+            where
+                A: EnumAccess<'de>,
             {
                 let (level, variant) = value.variant_seed(LevelIdentifier)?;
                 // Every variant is a unit variant.
@@ -82,7 +87,8 @@ impl<'de> Deserialize<'de> for Level {
 
 impl Serialize for LevelFilter {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         match *self {
             LevelFilter::Off => serializer.serialize_unit_variant("LevelFilter", 0, "OFF"),
@@ -97,7 +103,8 @@ impl Serialize for LevelFilter {
 
 impl<'de> Deserialize<'de> for LevelFilter {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         struct LevelFilterIdentifier;
 
@@ -109,7 +116,8 @@ impl<'de> Deserialize<'de> for LevelFilter {
             }
 
             fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-                where E: Error
+            where
+                E: Error,
             {
                 // Case insensitive.
                 FromStr::from_str(s).map_err(|_| Error::unknown_variant(s, &LOG_LEVEL_NAMES))
@@ -120,7 +128,8 @@ impl<'de> Deserialize<'de> for LevelFilter {
             type Value = LevelFilter;
 
             fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-                where D: Deserializer<'de>
+            where
+                D: Deserializer<'de>,
             {
                 deserializer.deserialize_identifier(LevelFilterIdentifier)
             }
@@ -136,7 +145,8 @@ impl<'de> Deserialize<'de> for LevelFilter {
             }
 
             fn visit_enum<A>(self, value: A) -> Result<Self::Value, A::Error>
-                where A: EnumAccess<'de>
+            where
+                A: EnumAccess<'de>,
             {
                 let (level_filter, variant) = value.variant_seed(LevelFilterIdentifier)?;
                 // Every variant is a unit variant.
@@ -172,11 +182,13 @@ mod tests {
 
     #[test]
     fn test_level_ser_de() {
-        let cases = [(Level::Error, [level_token("ERROR")]),
-                     (Level::Warn, [level_token("WARN")]),
-                     (Level::Info, [level_token("INFO")]),
-                     (Level::Debug, [level_token("DEBUG")]),
-                     (Level::Trace, [level_token("TRACE")])];
+        let cases = [
+            (Level::Error, [level_token("ERROR")]),
+            (Level::Warn, [level_token("WARN")]),
+            (Level::Info, [level_token("INFO")]),
+            (Level::Debug, [level_token("DEBUG")]),
+            (Level::Trace, [level_token("TRACE")]),
+        ];
 
         for &(s, expected) in &cases {
             assert_tokens(&s, &expected);
@@ -185,11 +197,13 @@ mod tests {
 
     #[test]
     fn test_level_case_insensitive() {
-        let cases = [(Level::Error, [level_token("error")]),
-                     (Level::Warn, [level_token("warn")]),
-                     (Level::Info, [level_token("info")]),
-                     (Level::Debug, [level_token("debug")]),
-                     (Level::Trace, [level_token("trace")])];
+        let cases = [
+            (Level::Error, [level_token("error")]),
+            (Level::Warn, [level_token("warn")]),
+            (Level::Info, [level_token("info")]),
+            (Level::Debug, [level_token("debug")]),
+            (Level::Trace, [level_token("trace")]),
+        ];
 
         for &(s, expected) in &cases {
             assert_de_tokens(&s, &expected);
@@ -205,12 +219,14 @@ mod tests {
 
     #[test]
     fn test_level_filter_ser_de() {
-        let cases = [(LevelFilter::Off, [level_filter_token("OFF")]),
-                     (LevelFilter::Error, [level_filter_token("ERROR")]),
-                     (LevelFilter::Warn, [level_filter_token("WARN")]),
-                     (LevelFilter::Info, [level_filter_token("INFO")]),
-                     (LevelFilter::Debug, [level_filter_token("DEBUG")]),
-                     (LevelFilter::Trace, [level_filter_token("TRACE")])];
+        let cases = [
+            (LevelFilter::Off, [level_filter_token("OFF")]),
+            (LevelFilter::Error, [level_filter_token("ERROR")]),
+            (LevelFilter::Warn, [level_filter_token("WARN")]),
+            (LevelFilter::Info, [level_filter_token("INFO")]),
+            (LevelFilter::Debug, [level_filter_token("DEBUG")]),
+            (LevelFilter::Trace, [level_filter_token("TRACE")]),
+        ];
 
         for &(s, expected) in &cases {
             assert_tokens(&s, &expected);
@@ -219,12 +235,14 @@ mod tests {
 
     #[test]
     fn test_level_filter_case_insensitive() {
-        let cases = [(LevelFilter::Off, [level_filter_token("off")]),
-                     (LevelFilter::Error, [level_filter_token("error")]),
-                     (LevelFilter::Warn, [level_filter_token("warn")]),
-                     (LevelFilter::Info, [level_filter_token("info")]),
-                     (LevelFilter::Debug, [level_filter_token("debug")]),
-                     (LevelFilter::Trace, [level_filter_token("trace")])];
+        let cases = [
+            (LevelFilter::Off, [level_filter_token("off")]),
+            (LevelFilter::Error, [level_filter_token("error")]),
+            (LevelFilter::Warn, [level_filter_token("warn")]),
+            (LevelFilter::Info, [level_filter_token("info")]),
+            (LevelFilter::Debug, [level_filter_token("debug")]),
+            (LevelFilter::Trace, [level_filter_token("trace")]),
+        ];
 
         for &(s, expected) in &cases {
             assert_de_tokens(&s, &expected);


### PR DESCRIPTION
It makes more sense to centrally locate that information.

Also run rustfmt.