### PR TITLE
Explicitly test against 1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 sudo: false
 rust:
   - 1.16.0
+  - stable
   - beta
   - nightly
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  - stable
+  - 1.16.0
   - beta
   - nightly
 script:


### PR DESCRIPTION
We want to know if we're dropping support for old releases.

r? @alexcrichton 