### PR TITLE
Fix broken links and bump the version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [0.4.1] - 2017-12-31
+
+Some doc links were fixed.
+
 ## [0.4.0] - 2017-12-24
 
 The changes in this release include cleanup of some obscure functionality and a more robust public
@@ -71,6 +75,7 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.1...HEAD
+[0.4.1]: https://github.com/rust-lang-nursery/log/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/rust-lang-nursery/log/compare/0.3.8...0.4.0
 [release tags]: https://github.com/rust-lang-nursery/log/releases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.0" # remember to update html_root_url
+version = "0.4.1" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://docs.rs/log/0.4.0")]
+       html_root_url = "https://docs.rs/log/0.4.1")]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]
 
@@ -447,11 +447,12 @@ impl Level {
 
 /// An enum representing the available verbosity level filters of the logger.
 ///
-/// A `LevelFilter` may be compared directly to a [`Level`](enum.Level.html).
-/// Use this type to [`get()`](struct.MaxLevelFilter.html#method.get) and
-/// [`set()`](struct.MaxLevelFilter.html#method.set) the
-/// [`MaxLevelFilter`](struct.MaxLevelFilter.html), or to match with the getter
-/// [`max_level()`](fn.max_level.html).
+/// A `LevelFilter` may be compared directly to a [`Level`]. Use this type
+/// to get and set the maximum log level with [`max_level()`] and [`set_max_level`].
+///
+/// [`Level`]: enum.Level.html
+/// [`max_level()`]: fn.max_level.html
+/// [`set_max_level`]: fn.set_max_level.html
 #[repr(usize)]
 #[derive(Copy, Eq, Debug, Hash)]
 pub enum LevelFilter {
@@ -600,7 +601,7 @@ impl LevelFilter {
 /// }
 /// ```
 ///
-/// [method.log]: trait.Log.html#method.log
+/// [method.log]: trait.Log.html#tymethod.log
 /// [`Log`]: trait.Log.html
 /// [`log!`]: macro.log.html
 /// [`level()`]: struct.Record.html#method.level


### PR DESCRIPTION
I don't know if this release needs a `CHANGELOG.md` entry, but if that is the case, I will be happy to add one.

This release is needed to unblock rust-lang/rust#46278.