### PR TITLE
List android_log crate in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ There are many available implementations to chose from, here are some of the mos
 * Adaptors for other facilities:
     * [`syslog`](https://docs.rs/syslog/*/syslog/)
     * [`slog-stdlog`](https://docs.rs/slog-stdlog/*/slog_stdlog/)
+    * [`android_log`](https://docs.rs/android_log/*/android_log/)
 
 Executables should choose a logger implementation and initialize it early in the
 runtime of the program. Logger implementations will typically include a


### PR DESCRIPTION
I'm not affiliated with the crate, but I think it's an interesting addition because it shows that logging can also be done cleanly on platforms like Android, not just on regular Linux.