### PR TITLE
explicitly test against 1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 sudo: false
 rust:
+  - 1.16.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Explicitly test against 1.16.0 like
fb65deee08b0f1d86102cb3ab49aba96b480d768 to ensure we know if support is
dropped. ref #148 