### PR TITLE
Level and LevelFilter can now be deserialized from byte slices

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -3,12 +3,12 @@
 extern crate serde;
 use self::serde::ser::{Serialize, Serializer};
 use self::serde::de::{Deserialize, DeserializeSeed, Deserializer, Visitor, EnumAccess,
-                      VariantAccess, Error};
+                      Unexpected, VariantAccess, Error};
 
 use {Level, LevelFilter, LOG_LEVEL_NAMES};
 
 use std::fmt;
-use std::str::FromStr;
+use std::str::{self, FromStr};
 
 // The Deserialize impls are handwritten to be case insensitive using FromStr.
 
@@ -53,7 +53,10 @@ impl<'de> Deserialize<'de> for Level {
             where
                 E: Error,
             {
-                self.visit_str(&*String::from_utf8_lossy(value))
+                let variant = str::from_utf8(value)
+                    .map_err(|_| Error::invalid_value(Unexpected::Bytes(value), &self))?;
+
+                self.visit_str(variant)
             }
         }
 
@@ -134,7 +137,10 @@ impl<'de> Deserialize<'de> for LevelFilter {
             where
                 E: Error,
             {
-                self.visit_str(&*String::from_utf8_lossy(value))
+                let variant = str::from_utf8(value)
+                    .map_err(|_| Error::invalid_value(Unexpected::Bytes(value), &self))?;
+
+                self.visit_str(variant)
             }
         }
 
@@ -176,7 +182,7 @@ impl<'de> Deserialize<'de> for LevelFilter {
 #[cfg(test)]
 mod tests {
     extern crate serde_test;
-    use self::serde_test::{Token, assert_tokens, assert_de_tokens, assert_de_tokens_error};
+    use self::serde_test::{assert_de_tokens, assert_de_tokens_error, assert_tokens, Token};
 
     use {Level, LevelFilter};
 


### PR DESCRIPTION
This is required by some deserializers which deserialize identifiers using their binary representation. An example of one such serializer is [Ron](https://github.com/ron-rs/ron/blob/a5a4b2ee21f5be0b07c55844e2689ae8a521da3b/src/de/mod.rs#L441-L446).

This implementation should be equivalent to what serde derive would [implement for enum variants](https://github.com/serde-rs/serde/blob/5efb22ebee128f1ec4a755556230bdd66c3f2026/serde_derive/src/de.rs#L2084-L2097).