### PR TITLE
Added Crate Feature Flags Documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@
 //! configured in your `Cargo.toml`.
 //!
 //! * `std` allows use of `std` crate instead of the default `core`. Enables using `std::error` and
-//! set_boxed_logger functionality.
+//! `set_boxed_logger` functionality.
 //! * `serde` enables support for serialization and deserialization of `Level` and `LevelFilter`.
 //!
 //! ```toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,19 @@
 //! [dependencies]
 //! log = { version = "0.4", features = ["max_level_debug", "release_max_level_warn"] }
 //! ```
+//! # Crate Feature Flags
+//!
+//! The following crate feature flags are avaliable in addition to the filters. They are
+//! configured in your `Cargo.toml`.
+//!
+//! * `std` allows use of `std` crate instead of the default `core`. Enables using `std::error` and
+//! set_boxed_logger functionality.
+//! * `serde` enables support for serialization and deserialization of `Level` and `LevelFilter`.
+//!
+//! ```toml
+//! [dependencies]
+//! log = { version = "0.4", features = ["std", "serde"] }
+//! ```
 //!
 //! # Version compatibility
 //!


### PR DESCRIPTION
I had difficulty figuring out why I couldn't get `serde` support, until I figured out that I was missing a feature flag in my `Cargo.toml`. This PR addresses that issue for others by adding a short section to the crate's docs about it.

Please make suggestions and comments, so that we can make rust's documentation even better!