### PR TITLE
Further optimize code size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1221,10 +1221,7 @@ pub fn logger() -> &'static Log {
 pub fn __private_api_log(
     args: fmt::Arguments,
     level: Level,
-    target: &str,
-    module_path: &str,
-    file: &str,
-    line: u32,
+    &(target, module_path, file, line): &(&str, &str, &str, u32),
 ) {
     logger().log(
         &Record::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,12 +375,52 @@ impl PartialOrd for Level {
     fn partial_cmp(&self, other: &Level) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
+
+    #[inline]
+    fn lt(&self, other: &Level) -> bool {
+        (*self as usize) < *other as usize
+    }
+
+    #[inline]
+    fn le(&self, other: &Level) -> bool {
+        *self as usize <= *other as usize
+    }
+
+    #[inline]
+    fn gt(&self, other: &Level) -> bool {
+        *self as usize > *other as usize
+    }
+
+    #[inline]
+    fn ge(&self, other: &Level) -> bool {
+        *self as usize >= *other as usize
+    }
 }
 
 impl PartialOrd<LevelFilter> for Level {
     #[inline]
     fn partial_cmp(&self, other: &LevelFilter) -> Option<cmp::Ordering> {
         Some((*self as usize).cmp(&(*other as usize)))
+    }
+
+    #[inline]
+    fn lt(&self, other: &LevelFilter) -> bool {
+        (*self as usize) < *other as usize
+    }
+
+    #[inline]
+    fn le(&self, other: &LevelFilter) -> bool {
+        *self as usize <= *other as usize
+    }
+
+    #[inline]
+    fn gt(&self, other: &LevelFilter) -> bool {
+        *self as usize > *other as usize
+    }
+
+    #[inline]
+    fn ge(&self, other: &LevelFilter) -> bool {
+        *self as usize >= *other as usize
     }
 }
 
@@ -517,12 +557,52 @@ impl PartialOrd for LevelFilter {
     fn partial_cmp(&self, other: &LevelFilter) -> Option<cmp::Ordering> {
         Some(self.cmp(other))
     }
+
+    #[inline]
+    fn lt(&self, other: &LevelFilter) -> bool {
+        (*self as usize) < *other as usize
+    }
+
+    #[inline]
+    fn le(&self, other: &LevelFilter) -> bool {
+        *self as usize <= *other as usize
+    }
+
+    #[inline]
+    fn gt(&self, other: &LevelFilter) -> bool {
+        *self as usize > *other as usize
+    }
+
+    #[inline]
+    fn ge(&self, other: &LevelFilter) -> bool {
+        *self as usize >= *other as usize
+    }
 }
 
 impl PartialOrd<Level> for LevelFilter {
     #[inline]
     fn partial_cmp(&self, other: &Level) -> Option<cmp::Ordering> {
-        other.partial_cmp(self).map(|x| x.reverse())
+        Some((*self as usize).cmp(&(*other as usize)))
+    }
+
+    #[inline]
+    fn lt(&self, other: &Level) -> bool {
+        (*self as usize) < *other as usize
+    }
+
+    #[inline]
+    fn le(&self, other: &Level) -> bool {
+        *self as usize <= *other as usize
+    }
+
+    #[inline]
+    fn gt(&self, other: &Level) -> bool {
+        *self as usize > *other as usize
+    }
+
+    #[inline]
+    fn ge(&self, other: &Level) -> bool {
+        *self as usize >= *other as usize
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,10 +37,7 @@ macro_rules! log {
             $crate::__private_api_log(
                 format_args!($($arg)+),
                 lvl,
-                $target,
-                module_path!(),
-                file!(),
-                line!(),
+                &($target, module_path!(), file!(), line!()),
             );
         }
     });


### PR DESCRIPTION
I had a look at #276 and thought I could do better!

There basically two areas where an improvement can be found:

- LLVM generates pretty poor code for the default implementations of `PartialOrd::{lt,le,gt,ge}` which forward to `partial_cmp`. So I added versions which perform the desired comparison directly.
- The target and location are almost always compile-time constants and can be passed in as a single argument which points to a static constant. This unfortunately doesn't work for the log level since we first need to make a local copy of it so that it is only evaluated once.

A main function containing nothing but `warn!("hello world")` shrinks from 160 bytes to 98 bytes in x86_64 with this change.