### PR TITLE
Elaborated documentation around log levels.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,8 @@
 //! The basic use of the log crate is through the five logging macros: [`error!`],
 //! [`warn!`], [`info!`], [`debug!`] and [`trace!`]
 //! where `error!` represents the highest-priority log messages
-//! and `trace!` the lowest. The log messages are filtered by setting the log
-//! level which means the level of verbosity: the lowest level doesn't log
-//! at all and the higher ones log increasingly much, starting from
-//! the high-priority messages; the highest level logs everything
-//! from `error!` to `trace!`.
+//! and `trace!` the lowest. The log messages are filtered by configuring
+//! the log level to exclude messages with a lower priority.
 //! Each of these macros accept format strings similarly to [`println!`].
 //!
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,12 @@
 //!
 //! The basic use of the log crate is through the five logging macros: [`error!`],
 //! [`warn!`], [`info!`], [`debug!`] and [`trace!`]
-//! where `error!` represents the highest-priority log level, and `trace!` the lowest.
-//!
+//! where `error!` represents the highest-priority log messages
+//! and `trace!` the lowest. The log messages are filtered by setting the log
+//! level which means the level of verbosity: the lowest level doesn't log
+//! at all and the higher ones log increasingly much, starting from
+//! the high-priority messages; the highest level logs everything
+//! from `error!` to `trace!`.
 //! Each of these macros accept format strings similarly to [`println!`].
 //!
 //!
@@ -220,7 +224,7 @@
 //! These features control the value of the `STATIC_MAX_LEVEL` constant. The logging macros check
 //! this value before logging a message. By default, no levels are disabled.
 //!
-//! For example, a crate can disable trace level logs in debug builds and trace, info, and warn
+//! For example, a crate can disable trace level logs in debug builds and trace, debug, and info
 //! level logs in release builds with the following configuration:
 //!
 //! ```toml


### PR DESCRIPTION
Two changes:

1) fixed the mistake in the example: `release_max_level_warn` disables `trace`, `debug`, and `info`, not `trace`, `info`, and `warn`.

2) The explanation of log levels was a bit misleading because it was said that `error!` represents the *highest-priority log level*. However, the *log level* that shows only `error` is the *lowest*. I removed the word level there, and added additional explanation about log levels as *the level of verbosity*. 