### PR TITLE
Ensure that initialization is complete after `set_logger_inner`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ use std::error;
 use std::fmt;
 use std::mem;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT, spin_loop_hint};
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
 #[macro_use]
 mod macros;
@@ -1158,9 +1158,7 @@ where
                 Ok(())
             }
             INITIALIZING => {
-                while STATE.load(Ordering::SeqCst) == INITIALIZING {
-                    spin_loop_hint();
-                }
+                while STATE.load(Ordering::SeqCst) == INITIALIZING {}
                 Err(SetLoggerError(()))
             }
             _ => Err(SetLoggerError(())),


### PR DESCRIPTION
If `set_logger_inner` is called while `STATE` is `INITIALIZING`, make it wait until the `STATE` is `INITIALIZED` so that callers can assume that the logging state is fully initialized after a call to `set_logger_inner`.

Note that this is a very simple implementation which could deadlock if `make_logger()` calls back into `set_logger_inner`, but that shouldn't happen since log's documentation says that `set_logger` should only be called once. If this is a concern, a more complex implementation that avoids this problem would be possible.

Fixes #286.
