### PR TITLE
Avoid format_args expansion when logging is disabled

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,12 +32,13 @@
 #[macro_export(local_inner_macros)]
 macro_rules! log {
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
+        let target = $target;
         let lvl = $lvl;
-        if lvl <= $crate::STATIC_MAX_LEVEL && lvl <= $crate::max_level() {
+        if log_enabled!(target: target, lvl) {
             $crate::__private_api_log(
                 __log_format_args!($($arg)+),
                 lvl,
-                &($target, __log_module_path!(), __log_file!(), __log_line!()),
+                &(target, __log_module_path!(), __log_file!(), __log_line!()),
             );
         }
     });


### PR DESCRIPTION
The `log_enabled!()` macro allows for expensive calls to be avoided when
logging is not enabled.  F.e. one could do

```rust
if log_enabled!(Debug) {
    log!(Debug, "{}", get_some_expensive_object());
}
```

This can be written shorter, actualy.  Right now, when logging is
disabled and `log!` is called, the expressions passed into the
`format_args!` are executed and expanded.  This means that the following
call would call `get_some_expensive_object()` *and* call
`fmt::Display::fmt` on the resulting type, even when logging is
disabled.

```rust
log!(Debug, "{}", get_some_expensive_object());
```

This change avoids executing the `log!` parameters and avoids the
`fmt::Display::fmt` call after that when logging is disabled.

This allows one-liner logs to be more efficient and avoids having to use
`log_enabled!` for one-liners.