### PR TITLE
Fixed Readme containing confusing instructions for Rust 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ pub fn shave_the_yak(yak: &mut Yak) {
 If you use Rust 2018, you can use instead the following code to import the crate macros:
 
 ```rust
+extern crate log;
 use log::{info, trace, warn};
 
 pub fn shave_the_yak(yak: &mut Yak) {


### PR DESCRIPTION
the new Rust 2018 notation does not remove the need for extern crate. However the example shown does not represent that.