### PR TITLE
Fix so log_enabled can be used without #[macro_use]

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -197,7 +197,7 @@ macro_rules! trace {
 /// # fn expensive_call() -> Data { Data { x: 0, y: 0 } }
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! log_enabled {
     (target: $target:expr, $lvl:expr) => {{
         let lvl = $lvl;


### PR DESCRIPTION
Fixes #300 

It seems that PR #288 missed to mark the `log_enabled` macro as `local_inner_macros`. This PR should hopefully make it possible to fully use this crate with the new way of importing macros.