### PR TITLE
Clarify what 2018 edition is a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pub fn shave_the_yak(yak: &mut Yak) {
 }
 ```
 
-If you use Rust 2018, you can use instead the following code to import the crate macros:
+If you use Rust 2018 (by setting `edition = 2018` in your `Cargo.toml`), you can use instead the following code to import the crate macros:
 
 ```rust
 use log::{info, trace, warn};


### PR DESCRIPTION
Just expands on what _Rust 2018_ is in the readme to avoid possible confusion. This came up in #298 