### PR TITLE
Improve error when missing macro argument

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -60,11 +60,11 @@ macro_rules! log {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! error {
-    (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Error, $($arg)*);
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, $crate::Level::Error, $($arg)+);
     );
-    ($($arg:tt)*) => (
-        log!($crate::Level::Error, $($arg)*);
+    ($($arg:tt)+) => (
+        log!($crate::Level::Error, $($arg)+);
     )
 }
 
@@ -84,11 +84,11 @@ macro_rules! error {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! warn {
-    (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Warn, $($arg)*);
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, $crate::Level::Warn, $($arg)+);
     );
-    ($($arg:tt)*) => (
-        log!($crate::Level::Warn, $($arg)*);
+    ($($arg:tt)+) => (
+        log!($crate::Level::Warn, $($arg)+);
     )
 }
 
@@ -110,11 +110,11 @@ macro_rules! warn {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! info {
-    (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Info, $($arg)*);
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, $crate::Level::Info, $($arg)+);
     );
-    ($($arg:tt)*) => (
-        log!($crate::Level::Info, $($arg)*);
+    ($($arg:tt)+) => (
+        log!($crate::Level::Info, $($arg)+);
     )
 }
 
@@ -135,11 +135,11 @@ macro_rules! info {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! debug {
-    (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Debug, $($arg)*);
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, $crate::Level::Debug, $($arg)+);
     );
-    ($($arg:tt)*) => (
-        log!($crate::Level::Debug, $($arg)*);
+    ($($arg:tt)+) => (
+        log!($crate::Level::Debug, $($arg)+);
     )
 }
 
@@ -162,11 +162,11 @@ macro_rules! debug {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! trace {
-    (target: $target:expr, $($arg:tt)*) => (
-        log!(target: $target, $crate::Level::Trace, $($arg)*);
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, $crate::Level::Trace, $($arg)+);
     );
-    ($($arg:tt)*) => (
-        log!($crate::Level::Trace, $($arg)*);
+    ($($arg:tt)+) => (
+        log!($crate::Level::Trace, $($arg)+);
     )
 }
 


### PR DESCRIPTION
The `log!` macro matches part of its arguments as `$($arg:tt)+`, but the other macros match it as `$($arg:tt)*`. That means if a user calls `error!()` or any of the other macros with an empty argument, it successfully matches the macro rules of the first macro they called but then turns into an invalid call to `log!`, leading to a confusing error message.

This PR uses `$($arg:tt)+` consistently to match arguments.

#### Example:

```rust
use log::error;

fn main() {
    error!();
}
```

#### Before:

```console
error: expected identifier, found `,`
 --> src/main.rs:4:5
  |
4 |     error!();
  |     ^^^^^^^^^
  |     |
  |     expected identifier
  |     help: remove this comma
  |
  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
```

#### After:

```console
error: unexpected end of macro invocation
 --> src/main.rs:4:5
  |
4 |     error!();
  |     ^^^^^^^^^ missing tokens in macro arguments
```

Closes https://github.com/rust-lang-nursery/log/issues/271#issuecomment-464369661.