### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/log"
 documentation = "https://docs.rs/log"
-homepage = "https://github.com/rust-lang/log"
 description = """
 A lightweight logging facade for Rust
 """


### PR DESCRIPTION
As per the [C-METADATA](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#c-metadata) API guideline, the `homepage` field aims to provide a unique, dedicated website for the project. Since this one is only replicating `repository`, I believe that it is best removed for the time being.