### PR TITLE
Thumbv6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ rust:
   - stable
   - beta
   - nightly
+install:
+  - rustup target add thumbv6m-none-eabi
 script:
   - cargo build --verbose
   - cargo build --verbose --features serde
   - cargo build --verbose --features std
+  - cargo build --verbose --target=thumbv6m-none-eabi
   - cargo test --verbose
   - cargo test --verbose --features serde
   - cargo test --verbose --features std

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ rust:
   - beta
   - nightly
 install:
-  - rustup target add thumbv6m-none-eabi
+  - '[ "$TRAVIS_RUST_VERSION" == "1.16.0" ] || rustup target add thumbv6m-none-eabi'
 script:
   - cargo build --verbose
   - cargo build --verbose --features serde
   - cargo build --verbose --features std
-  - cargo build --verbose --target=thumbv6m-none-eabi
+  - '[ "$TRAVIS_RUST_VERSION" == "1.16.0" ] || cargo build --verbose --target=thumbv6m-none-eabi'
   - cargo test --verbose
   - cargo test --verbose --features serde
   - cargo test --verbose --features std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ A lightweight logging facade for Rust
 categories = ["development-tools::debugging"]
 keywords = ["logging"]
 exclude = ["rfcs/**/*", "/.travis.yml", "/appveyor.yml"]
+build = "build.rs"
 
 [package.metadata.docs.rs]
 features = ["std", "serde"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+//! This build script detects target platforms that lack proper support for
+//! atomics and sets `cfg` flags accordingly.
+
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+
+    if !target.starts_with("thumbv6") {
+        println!("cargo:rustc-cfg=atomic_cas");
+    }
+
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1102,7 +1102,7 @@ pub fn max_level() -> LevelFilter {
 /// An error is returned if a logger has already been set.
 ///
 /// [`set_logger`]: fn.set_logger.html
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", atomic_cas))]
 pub fn set_boxed_logger(logger: Box<Log>) -> Result<(), SetLoggerError> {
     set_logger_inner(|| unsafe { &*Box::into_raw(logger) })
 }
@@ -1115,6 +1115,13 @@ pub fn set_boxed_logger(logger: Box<Log>) -> Result<(), SetLoggerError> {
 /// This function does not typically need to be called manually. Logger
 /// implementations should provide an initialization method that installs the
 /// logger internally.
+///
+/// # Availability
+///
+/// This method is available even when the `std` feature is disabled. However,
+/// it is currently unavailable on `thumbv6` targets, which lack support for
+/// some atomic operations which are used by this function. However, even on
+/// those targets, [`set_logger_racy`] is available.
 ///
 /// # Errors
 ///
@@ -1154,10 +1161,14 @@ pub fn set_boxed_logger(logger: Box<Log>) -> Result<(), SetLoggerError> {
 /// error!("oops");
 /// # }
 /// ```
+///
+/// [`set_logger_racy`]: fn.set_logger_racy.html
+#[cfg(atomic_cas)]
 pub fn set_logger(logger: &'static Log) -> Result<(), SetLoggerError> {
     set_logger_inner(|| logger)
 }
 
+#[cfg(atomic_cas)]
 fn set_logger_inner<F>(make_logger: F) -> Result<(), SetLoggerError>
 where
     F: FnOnce() -> &'static Log,
@@ -1175,6 +1186,36 @@ where
             }
             _ => Err(SetLoggerError(())),
         }
+    }
+}
+
+/// A thread-unsafe version of [`set_logger`].
+///
+/// This function is available on all platforms, even those that do not have
+/// support for atomics that is needed by [`set_logger`].
+///
+/// In almost all cases, [`set_logger`] should be preferred.
+///
+/// # Safety
+///
+/// This function is only safe to call when there is no chance that any of its
+/// operations will be preempted. This usually means that **there must not be
+/// any active threads**, and (on embedded) that **interrupts must be
+/// disabled**.
+///
+/// [`set_logger`]: fn.set_logger.html
+pub unsafe fn set_logger_racy(logger: &'static Log) -> Result<(), SetLoggerError> {
+    match STATE.load(Ordering::SeqCst) {
+        UNINITIALIZED => {
+            LOGGER = logger;
+            STATE.store(INITIALIZED, Ordering::SeqCst);
+            Ok(())
+        }
+        INITIALIZING => {
+            // This is just plain UB, since we were racing another initialization function
+            unreachable!("set_logger_racy must not be used with other initialization functions")
+        },
+        _ => Err(SetLoggerError(())),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1120,8 +1120,8 @@ pub fn set_boxed_logger(logger: Box<Log>) -> Result<(), SetLoggerError> {
 ///
 /// This method is available even when the `std` feature is disabled. However,
 /// it is currently unavailable on `thumbv6` targets, which lack support for
-/// some atomic operations which are used by this function. However, even on
-/// those targets, [`set_logger_racy`] is available.
+/// some atomic operations which are used by this function. Even on those
+/// targets, [`set_logger_racy`] will be available.
 ///
 /// # Errors
 ///
@@ -1203,6 +1203,9 @@ where
 ///
 /// This can be upheld by (for example) making sure that **there are no other
 /// threads**, and (on embedded) that **interrupts are disabled**.
+///
+/// It is safe to use other logging functions while this function runs
+/// (including all logging macros).
 ///
 /// [`set_logger`]: fn.set_logger.html
 pub unsafe fn set_logger_racy(logger: &'static Log) -> Result<(), SetLoggerError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1198,10 +1198,11 @@ where
 ///
 /// # Safety
 ///
-/// This function is only safe to call when there is no chance that any of its
-/// operations will be preempted. This usually means that **there must not be
-/// any active threads**, and (on embedded) that **interrupts must be
-/// disabled**.
+/// This function is only safe to call when no other logger initialization
+/// function is called while this function still executes.
+///
+/// This can be upheld by (for example) making sure that **there are no other
+/// threads**, and (on embedded) that **interrupts are disabled**.
 ///
 /// [`set_logger`]: fn.set_logger.html
 pub unsafe fn set_logger_racy(logger: &'static Log) -> Result<(), SetLoggerError> {
@@ -1214,7 +1215,7 @@ pub unsafe fn set_logger_racy(logger: &'static Log) -> Result<(), SetLoggerError
         INITIALIZING => {
             // This is just plain UB, since we were racing another initialization function
             unreachable!("set_logger_racy must not be used with other initialization functions")
-        },
+        }
         _ => Err(SetLoggerError(())),
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/rust-lang-nursery/log/issues/285, this adds another initialization function, `set_logger_racy`, which doesn't use `compare_and_swap` and is unsafe.

This allows `log` to support platforms that lack CAS support, which includes `thumbv6`. I haven't added any other architecture since I don't know how the exact support matrix for atomics looks.

Closes https://github.com/rust-lang-nursery/log/issues/285