### PR TITLE
Add a count method to Source

### DIFF
--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -10,21 +10,25 @@ use kv::{Error, Key, ToKey, Value, ToValue};
 pub trait Source {
     /// Visit key-value pairs.
     /// 
+    /// A source doesn't have to guarantee any ordering or uniqueness of key-value pairs.
+    /// If the given visitor returns an error then the source may early-return with it,
+    /// even if there are more key-value pairs.
+    /// 
     /// # Implementation notes
     /// 
-    /// A source doesn't have to guarantee any ordering or uniqueness of key-value pairs.
-    /// If the given visitor returns an error then the source may early-return with it.
-    /// 
-    /// A source should always yield the same key-value pairs to the visitor unless it
-    /// returns an error.
+    /// A source should yield the same key-value pairs to a subsequent visitor unless
+    /// that visitor itself fails.
     fn visit<'kvs>(&'kvs self, visitor: &mut Visitor<'kvs>) -> Result<(), Error>;
 
-    /// Count the number of key-value pairs that are passed to a visitor.
+    /// Count the number of key-value pairs that can be visited.
     /// 
     /// # Implementation notes
     /// 
     /// A source that knows the number of key-value pairs upfront may provide a more
     /// efficient implementation.
+    /// 
+    /// A subsequent call to `visit` should yield the same number of key-value pairs
+    /// to the visitor, unless that visitor fails part way through.
     fn count(&self) -> usize {
         struct Count(usize);
 


### PR DESCRIPTION
Adds a `Source::count(&self) -> usize` method to figure out how many key-value pairs to expect.

I've also tried to clarify the expectation that subsequent calls to `Source::visit` will yield the same key-value pairs unless the visitor fails. A buggy `Source::visit` with the default implementation of `count` may yield a different number of key-value pairs. Given that, we could make the method something like `Source::size_hint(&self) -> Option<usize>` instead, but I think the fundamental requirement that `Source::visit` passes the same pairs to the visitor unless the visitor itself fails is reasonable and lets us add more useful methods like `for_each` that don't have to return results. The reason `visit` itself is fallible is so that a formatting or serialization error can be passed upstream for a logging framework to surface in some way.