### PR TITLE
Respect padding for LevelFilter Display

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -638,7 +638,7 @@ impl FromStr for LevelFilter {
 
 impl fmt::Display for LevelFilter {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}", LOG_LEVEL_NAMES[*self as usize])
+        fmt.pad(LOG_LEVEL_NAMES[*self as usize])
     }
 }
 


### PR DESCRIPTION
This mirrors a similar commit fe073054a0999d1bb238cb0293757741e95b3588
that changed output for Level, it seems sensible if the user wishes to
output the logging filter level to afford the same formatting choices.