### PR TITLE
Add a Source::get method for finding a single value

### DIFF
--- a/src/kv/value/impls.rs
+++ b/src/kv/value/impls.rs
@@ -264,151 +264,33 @@ mod std_support {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kv::value::Error;
-    use kv::value::internal::Visitor;
-
-    use std::fmt::Write;
-    use std::str::{self, Utf8Error};
-
-    // A quick-and-dirty no-std buffer
-    // to write strings into
-    struct Buffer {
-        buf: [u8; 16],
-        len: usize,
-    }
-
-    impl Buffer {
-        fn new() -> Self {
-            Buffer {
-                buf: [0; 16],
-                len: 0,
-            }
-        }
-
-        fn as_str(&self) -> Result<&str, Utf8Error> {
-            str::from_utf8(&self.buf[0..self.len])
-        }
-    }
-
-    impl Write for Buffer {
-        fn write_str(&mut self, s: &str) -> fmt::Result {
-            let bytes = s.as_bytes();
-
-            let end = self.len + bytes.len();
-
-            if end > 16 {
-                panic!("`{}` would overflow", s);
-            }
-
-            let buf = &mut self.buf[self.len..end];
-            buf.copy_from_slice(bytes);
-            self.len = end;
-
-            Ok(())
-        }
-    }
+    use kv::value::test::Token;
 
     #[test]
     fn test_to_value_display() {
-        // Write a value into our buffer using `<Value as Display>::fmt`
-        fn check(value: Value, expected: &str) {
-            let mut buf = Buffer::new();
-            write!(&mut buf, "{}", value).unwrap();
-
-            assert_eq!(expected, buf.as_str().unwrap());
-        }
-
-        check(42u64.to_value(), "42");
-        check(42i64.to_value(), "42");
-        check(42.01f64.to_value(), "42.01");
-        check(true.to_value(), "true");
-        check('a'.to_value(), "'a'");
-        check(format_args!("a {}", "value").to_value(), "a value");
-        check("a loong string".to_value(), "\"a loong string\"");
-        check(Some(true).to_value(), "true");
-        check(().to_value(), "None");
-        check(Option::None::<bool>.to_value(), "None");
+        assert_eq!(42u64.to_value().to_str_buf(), "42");
+        assert_eq!(42i64.to_value().to_str_buf(), "42");
+        assert_eq!(42.01f64.to_value().to_str_buf(), "42.01");
+        assert_eq!(true.to_value().to_str_buf(), "true");
+        assert_eq!('a'.to_value().to_str_buf(), "'a'");
+        assert_eq!(format_args!("a {}", "value").to_value().to_str_buf(), "a value");
+        assert_eq!("a loong string".to_value().to_str_buf(), "\"a loong string\"");
+        assert_eq!(Some(true).to_value().to_str_buf(), "true");
+        assert_eq!(().to_value().to_str_buf(), "None");
+        assert_eq!(Option::None::<bool>.to_value().to_str_buf(), "None");
     }
 
     #[test]
     fn test_to_value_structured() {
-        #[derive(Debug, PartialEq)]
-        enum Token<'a> {
-            U64(u64),
-            I64(i64),
-            F64(f64),
-            Char(char),
-            Bool(bool),
-            Str(&'a str),
-            None,
-        }
-
-        struct TestVisitor<F>(F);
-
-        impl<F> Visitor for TestVisitor<F>
-        where
-            F: Fn(Token),
-        {
-            fn debug(&mut self, v: &fmt::Debug) -> Result<(), Error> {
-                let mut buf = Buffer::new();
-                write!(&mut buf, "{:?}", v)?;
-
-                let s = buf.as_str().map_err(|_| Error::msg("invalid UTF8"))?;
-                (self.0)(Token::Str(s));
-                Ok(())
-            }
-
-            fn u64(&mut self, v: u64) -> Result<(), Error> {
-                (self.0)(Token::U64(v));
-                Ok(())
-            }
-
-            fn i64(&mut self, v: i64) -> Result<(), Error> {
-                (self.0)(Token::I64(v));
-                Ok(())
-            }
-
-            fn f64(&mut self, v: f64) -> Result<(), Error> {
-                (self.0)(Token::F64(v));
-                Ok(())
-            }
-
-            fn bool(&mut self, v: bool) -> Result<(), Error> {
-                (self.0)(Token::Bool(v));
-                Ok(())
-            }
-
-            fn char(&mut self, v: char) -> Result<(), Error> {
-                (self.0)(Token::Char(v));
-                Ok(())
-            }
-
-            fn str(&mut self, v: &str) -> Result<(), Error> {
-                (self.0)(Token::Str(v));
-                Ok(())
-            }
-
-            fn none(&mut self) -> Result<(), Error> {
-                (self.0)(Token::None);
-                Ok(())
-            }
-        }
-
-        // Check that a value retains the right structure
-        fn check(value: Value, expected: Token) {
-            let mut visitor = TestVisitor(|token: Token| assert_eq!(expected, token));
-            value.visit(&mut visitor).unwrap();
-        }
-
-        check(42u64.to_value(), Token::U64(42));
-        check(42i64.to_value(), Token::I64(42));
-        check(42.01f64.to_value(), Token::F64(42.01));
-        check(true.to_value(), Token::Bool(true));
-        check('a'.to_value(), Token::Char('a'));
-        check(format_args!("a {}", "value").to_value(), Token::Str("a value"));
-        check("a loong string".to_value(), Token::Str("a loong string"));
-        check(Some(true).to_value(), Token::Bool(true));
-        check(().to_value(), Token::None);
-        check(Option::None::<bool>.to_value(), Token::None);
+        assert_eq!(42u64.to_value().to_token(), Token::U64(42));
+        assert_eq!(42i64.to_value().to_token(), Token::I64(42));
+        assert_eq!(42.01f64.to_value().to_token(), Token::F64(42.01));
+        assert_eq!(true.to_value().to_token(), Token::Bool(true));
+        assert_eq!('a'.to_value().to_token(), Token::Char('a'));
+        assert_eq!(format_args!("a {}", "value").to_value().to_token(), Token::Str("a value".into()));
+        assert_eq!("a loong string".to_value().to_token(), Token::Str("a loong string".into()));
+        assert_eq!(Some(true).to_value().to_token(), Token::Bool(true));
+        assert_eq!(().to_value().to_token(), Token::None);
+        assert_eq!(Option::None::<bool>.to_value().to_token(), Token::None);
     }
 }

--- a/src/kv/value/mod.rs
+++ b/src/kv/value/mod.rs
@@ -5,6 +5,9 @@ use std::fmt;
 mod internal;
 mod impls;
 
+#[cfg(test)]
+pub(in kv) mod test;
+
 use kv::Error;
 
 use self::internal::{Inner, Visit, Visitor};

--- a/src/kv/value/test.rs
+++ b/src/kv/value/test.rs
@@ -1,0 +1,156 @@
+// Test support for inspecting Values
+
+use std::fmt::{self, Write};
+use std::str;
+
+use super::{Value, Error};
+use super::internal::Visitor;
+
+#[derive(Debug, PartialEq)]
+pub(in kv) enum Token {
+    U64(u64),
+    I64(i64),
+    F64(f64),
+    Char(char),
+    Bool(bool),
+    Str(StrBuf),
+    None,
+}
+
+#[derive(Debug, PartialEq)]
+pub(in kv) struct StrBuf {
+    buf: [u8; 16],
+    len: usize,
+}
+
+impl<'a> From<&'a str> for StrBuf {
+    fn from(s: &'a str) -> Self {
+        let mut buf = Buffer::new();
+        write!(&mut buf, "{}", s).unwrap();
+
+        buf.into_str_buf()
+    }
+}
+
+impl PartialEq<str> for StrBuf {
+    fn eq(&self, other: &str) -> bool {
+        self.as_ref() == other
+    }
+}
+
+impl<'a> PartialEq<&'a str> for StrBuf {
+    fn eq(&self, other: &&'a str) -> bool {
+        self.as_ref() == *other
+    }
+}
+
+impl AsRef<str> for StrBuf {
+    fn as_ref(&self) -> &str {
+        str::from_utf8(&self.buf[0..self.len]).unwrap()
+    }
+}
+
+#[cfg(test)]
+impl<'v> Value<'v> {
+    pub(in kv) fn to_token(&self) -> Token {
+        struct TestVisitor(Option<Token>);
+
+        impl Visitor for TestVisitor {
+            fn debug(&mut self, v: &fmt::Debug) -> Result<(), Error> {
+                let mut buf = Buffer::new();
+                write!(&mut buf, "{:?}", v)?;
+
+                self.0 = Some(Token::Str(buf.into_str_buf()));
+                Ok(())
+            }
+
+            fn u64(&mut self, v: u64) -> Result<(), Error> {
+                self.0 = Some(Token::U64(v));
+                Ok(())
+            }
+
+            fn i64(&mut self, v: i64) -> Result<(), Error> {
+                self.0 = Some(Token::I64(v));
+                Ok(())
+            }
+
+            fn f64(&mut self, v: f64) -> Result<(), Error> {
+                self.0 = Some(Token::F64(v));
+                Ok(())
+            }
+
+            fn bool(&mut self, v: bool) -> Result<(), Error> {
+                self.0 = Some(Token::Bool(v));
+                Ok(())
+            }
+
+            fn char(&mut self, v: char) -> Result<(), Error> {
+                self.0 = Some(Token::Char(v));
+                Ok(())
+            }
+
+            fn str(&mut self, v: &str) -> Result<(), Error> {
+                self.0 = Some(Token::Str(v.into()));
+                Ok(())
+            }
+
+            fn none(&mut self) -> Result<(), Error> {
+                self.0 = Some(Token::None);
+                Ok(())
+            }
+        }
+
+        let mut visitor = TestVisitor(None);
+        self.visit(&mut visitor).unwrap();
+
+        visitor.0.unwrap()
+    }
+
+    pub(in kv) fn to_str_buf(&self) -> StrBuf {
+        let mut buf = Buffer::new();
+        write!(&mut buf, "{}", self).unwrap();
+
+        buf.into_str_buf()
+    }
+}
+
+// A quick-and-dirty no-std buffer
+// to write strings into
+struct Buffer {
+    buf: [u8; 16],
+    len: usize,
+}
+
+impl Buffer {
+    fn new() -> Self {
+        Buffer {
+            buf: [0; 16],
+            len: 0,
+        }
+    }
+
+    fn into_str_buf(self) -> StrBuf {
+        StrBuf {
+            buf: self.buf,
+            len: self.len,
+        }
+    }
+}
+
+impl Write for Buffer {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let bytes = s.as_bytes();
+
+        let end = self.len + bytes.len();
+
+        if end > 16 {
+            panic!("`{}` would overflow", s);
+        }
+
+        let buf = &mut self.buf[self.len..end];
+        buf.copy_from_slice(bytes);
+        self.len = end;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Part of #149

Adds `get` to `Source` for fetching a single value:

```rust
fn get<'v>(&'v self, key: Key) -> Option<Value<'v>> { .. }
```

It's useful for cases where you want to find 'well-known' key values like timestamps, errors, trace ids etc.

The method needs to be object-safe, so it takes a concrete `Key` instead of a generic type. It could take a `&dyn ToKey` instead, which could have nicer ergonomics, but I opted for the simpler API to start with.

The method has a default implementation that has a O(N) cost. It will always look at all key-value pairs. Implementations for types like maps or concrete structs can override this to be more efficient. For implementations that we own we could use the `Result` to early return when a match is found instead of continuing to look for a match.

I've also refactored the test utilities we're using to check implementations of `Value` so they can be used in other tests too.