### PR TITLE
Remove duplicate Rust 2018 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,6 @@ pub fn shave_the_yak(yak: &mut Yak) {
 }
 ```
 
-If you use Rust 2018 (by setting `edition = 2018` in your `Cargo.toml`), you can use instead the following code to import the crate macros:
-
-```rust
-use log::{info, trace, warn};
-
-pub fn shave_the_yak(yak: &mut Yak) {
-    // …
-}
-```
-
 ## In executables
 
 In order to produce log output, executables have to use a logger implementation compatible with the facade.


### PR DESCRIPTION
This is a follow-up for changes 0da424552703 and 0f3ffb9d051c.