### PR TITLE
Make it easier to create a Value from owned or erased external types

### DIFF
--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -3,7 +3,7 @@
 mod error;
 mod source;
 mod key;
-mod value;
+pub mod value;
 
 pub use self::error::Error;
 pub use self::source::{Source, Visitor};

--- a/src/kv/source.rs
+++ b/src/kv/source.rs
@@ -1,5 +1,6 @@
 //! Sources for key-value pairs.
 
+use std::fmt;
 use kv::{Error, Key, ToKey, Value, ToValue};
 
 /// A source of key-value pairs.
@@ -165,6 +166,35 @@ where
 {
     fn visit_pair(&mut self, key: Key<'kvs>, value: Value<'kvs>) -> Result<(), Error> {
         (**self).visit_pair(key, value)
+    }
+}
+
+impl<'a, 'b: 'a, 'kvs> Visitor<'kvs> for fmt::DebugMap<'a, 'b> {
+    fn visit_pair(&mut self, key: Key<'kvs>, value: Value<'kvs>) -> Result<(), Error> {
+        self.entry(&key, &value);
+        Ok(())
+    }
+}
+
+impl<'a, 'b: 'a, 'kvs> Visitor<'kvs> for fmt::DebugList<'a, 'b> {
+    fn visit_pair(&mut self, key: Key<'kvs>, value: Value<'kvs>) -> Result<(), Error> {
+        self.entry(&(key, value));
+        Ok(())
+    }
+}
+
+impl<'a, 'b: 'a, 'kvs> Visitor<'kvs> for fmt::DebugSet<'a, 'b> {
+    fn visit_pair(&mut self, key: Key<'kvs>, value: Value<'kvs>) -> Result<(), Error> {
+        self.entry(&(key, value));
+        Ok(())
+    }
+}
+
+impl<'a, 'b: 'a, 'kvs> Visitor<'kvs> for fmt::DebugTuple<'a, 'b> {
+    fn visit_pair(&mut self, key: Key<'kvs>, value: Value<'kvs>) -> Result<(), Error> {
+        self.field(&key);
+        self.field(&value);
+        Ok(())
     }
 }
 

--- a/src/kv/value/impls.rs
+++ b/src/kv/value/impls.rs
@@ -1,196 +1,190 @@
 use std::fmt;
 
-use super::{Error, ToValue, Value, Visit, Visitor};
+use super::{ToValue, Value, Primitive};
 
 impl ToValue for usize {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for usize {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.u64(*self as u64)
+impl<'v> From<usize> for Value<'v> {
+    fn from(value: usize) -> Self {
+        Value::from_primitive(Primitive::Unsigned(value as u64))
     }
 }
 
 impl ToValue for isize {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for isize {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.i64(*self as i64)
+impl<'v> From<isize> for Value<'v> {
+    fn from(value: isize) -> Self {
+        Value::from_primitive(Primitive::Signed(value as i64))
     }
 }
 
 impl ToValue for u8 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for u8 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.u64(*self as u64)
+impl<'v> From<u8> for Value<'v> {
+    fn from(value: u8) -> Self {
+        Value::from_primitive(Primitive::Unsigned(value as u64))
     }
 }
 
 impl ToValue for u16 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for u16 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.u64(*self as u64)
+impl<'v> From<u16> for Value<'v> {
+    fn from(value: u16) -> Self {
+        Value::from_primitive(Primitive::Unsigned(value as u64))
     }
 }
 
 impl ToValue for u32 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for u32 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.u64(*self as u64)
+impl<'v> From<u32> for Value<'v> {
+    fn from(value: u32) -> Self {
+        Value::from_primitive(Primitive::Unsigned(value as u64))
     }
 }
 
 impl ToValue for u64 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for u64 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.u64(*self)
+impl<'v> From<u64> for Value<'v> {
+    fn from(value: u64) -> Self {
+        Value::from_primitive(Primitive::Unsigned(value))
     }
 }
 
 impl ToValue for i8 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for i8 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.i64(*self as i64)
+impl<'v> From<i8> for Value<'v> {
+    fn from(value: i8) -> Self {
+        Value::from_primitive(Primitive::Signed(value as i64))
     }
 }
 
 impl ToValue for i16 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for i16 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.i64(*self as i64)
+impl<'v> From<i16> for Value<'v> {
+    fn from(value: i16) -> Self {
+        Value::from_primitive(Primitive::Signed(value as i64))
     }
 }
 
 impl ToValue for i32 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for i32 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.i64(*self as i64)
+impl<'v> From<i32> for Value<'v> {
+    fn from(value: i32) -> Self {
+        Value::from_primitive(Primitive::Signed(value as i64))
     }
 }
 
 impl ToValue for i64 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for i64 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.i64(*self)
+impl<'v> From<i64> for Value<'v> {
+    fn from(value: i64) -> Self {
+        Value::from_primitive(Primitive::Signed(value))
     }
 }
 
 impl ToValue for f32 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for f32 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.f64(*self as f64)
+impl<'v> From<f32> for Value<'v> {
+    fn from(value: f32) -> Self {
+        Value::from_primitive(Primitive::Float(value as f64))
     }
 }
 
 impl ToValue for f64 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for f64 {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.f64(*self)
+impl<'v> From<f64> for Value<'v> {
+    fn from(value: f64) -> Self {
+        Value::from_primitive(Primitive::Float(value))
     }
 }
 
 impl ToValue for bool {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for bool {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.bool(*self)
+impl<'v> From<bool> for Value<'v> {
+    fn from(value: bool) -> Self {
+        Value::from_primitive(Primitive::Bool(value))
     }
 }
 
 impl ToValue for char {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl Visit for char {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.char(*self)
+impl<'v> From<char> for Value<'v> {
+    fn from(value: char) -> Self {
+        Value::from_primitive(Primitive::Char(value))
     }
 }
 
 impl<'v> ToValue for &'v str {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
+        Value::from(*self)
     }
 }
 
-impl<'v> Visit for &'v str {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.str(*self)
+impl<'v> From<&'v str> for Value<'v> {
+    fn from(value: &'v str) -> Self {
+        Value::from_primitive(Primitive::Str(value))
     }
 }
 
 impl ToValue for () {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
-    }
-}
-
-impl Visit for () {
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-        visitor.none()
+        Value::from_primitive(Primitive::None)
     }
 }
 
@@ -199,18 +193,9 @@ where
     T: ToValue,
 {
     fn to_value(&self) -> Value {
-        Value::from_internal(self)
-    }
-}
-
-impl<T> Visit for Option<T>
-where
-    T: ToValue,
-{
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
         match *self {
-            Some(ref value) => value.to_value().visit(visitor),
-            None => visitor.none(),
+            Some(ref value) => value.to_value(),
+            None => Value::from_primitive(Primitive::None),
         }
     }
 }
@@ -238,25 +223,13 @@ mod std_support {
 
     impl ToValue for String {
         fn to_value(&self) -> Value {
-            Value::from_internal(self)
+            Value::from_primitive(Primitive::Str(&*self))
         }
     }
 
-    impl Visit for String {
-        fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-            visitor.str(&*self)
-        }
-    }
-
-    impl<'a> ToValue for Cow<'a, str> {
+    impl<'v> ToValue for Cow<'v, str> {
         fn to_value(&self) -> Value {
-            Value::from_internal(self)
-        }
-    }
-
-    impl<'a> Visit for Cow<'a, str> {
-        fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
-            visitor.str(&*self)
+            Value::from_primitive(Primitive::Str(&*self))
         }
     }
 }

--- a/src/kv/value/internal.rs
+++ b/src/kv/value/internal.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use super::Error;
+use super::{Fill, Slot, Error};
 
 // `Visit` and `Visitor` is an internal API for visiting the structure of a value.
 // It's not intended to be public (at this stage).
@@ -12,9 +12,10 @@ use super::Error;
 /// A container for a structured value for a specific kind of visitor.
 #[derive(Clone, Copy)]
 pub(super) enum Inner<'v> {
-    /// An internal `Visit`. It'll be an internal structure-preserving
-    /// type from the standard library that's implemented in this crate.
-    Internal(&'v Visit),
+    /// A simple primitive value that can be copied without allocating.
+    Primitive(Primitive<'v>),
+    /// A value that can be filled.
+    Fill(&'v Fill),
     /// A debuggable value.
     Debug(&'v fmt::Debug),
     /// A displayable value.
@@ -24,16 +25,20 @@ pub(super) enum Inner<'v> {
 impl<'v> Inner<'v> {
     pub(super) fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
         match *self {
-            Inner::Internal(ref value) => value.visit(visitor),
-            Inner::Debug(ref value) => visitor.debug(value),
-            Inner::Display(ref value) => visitor.display(value),
+            Inner::Primitive(value) => match value {
+                Primitive::Signed(value) => visitor.i64(value),
+                Primitive::Unsigned(value) => visitor.u64(value),
+                Primitive::Float(value) => visitor.f64(value),
+                Primitive::Bool(value) => visitor.bool(value),
+                Primitive::Char(value) => visitor.char(value),
+                Primitive::Str(value) => visitor.str(value),
+                Primitive::None => visitor.none(),
+            },
+            Inner::Fill(value) => value.fill(Slot::new(visitor)),
+            Inner::Debug(value) => visitor.debug(value),
+            Inner::Display(value) => visitor.display(value),
         }
     }
-}
-
-/// An internal structure-preserving value.
-pub(super) trait Visit {
-    fn visit(&self, backend: &mut Visitor) -> Result<(), Error>;
 }
 
 /// The internal serialization contract.
@@ -50,6 +55,17 @@ pub(super) trait Visitor {
     fn char(&mut self, v: char) -> Result<(), Error>;
     fn str(&mut self, v: &str) -> Result<(), Error>;
     fn none(&mut self) -> Result<(), Error>;
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum Primitive<'v> {
+    Signed(i64),
+    Unsigned(u64),
+    Float(f64),
+    Bool(bool),
+    Char(char),
+    Str(&'v str),
+    None,
 }
 
 /// A visitor for `std::fmt`.

--- a/src/kv/value/internal.rs
+++ b/src/kv/value/internal.rs
@@ -34,7 +34,7 @@ impl<'v> Inner<'v> {
                 Primitive::Str(value) => visitor.str(value),
                 Primitive::None => visitor.none(),
             },
-            Inner::Fill(value) => value.fill(Slot::new(visitor)),
+            Inner::Fill(value) => value.fill(&mut Slot::new(visitor)),
             Inner::Debug(value) => visitor.debug(value),
             Inner::Display(value) => visitor.display(value),
         }

--- a/src/kv/value/test.rs
+++ b/src/kv/value/test.rs
@@ -44,6 +44,12 @@ impl<'a> PartialEq<&'a str> for StrBuf {
     }
 }
 
+impl<'a> PartialEq<StrBuf> for &'a str {
+    fn eq(&self, other: &StrBuf) -> bool {
+        *self == other.as_ref()
+    }
+}
+
 impl AsRef<str> for StrBuf {
     fn as_ref(&self) -> &str {
         str::from_utf8(&self.buf[0..self.len]).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,21 +736,9 @@ struct KeyValues<'a>(&'a kv::Source);
 #[cfg(feature = "kv_unstable")]
 impl<'a> fmt::Debug for KeyValues<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::kv::{Key, Value, Visitor, Error};
-
-        struct FmtVisitor<'a, 'b: 'a>(fmt::DebugMap<'a, 'b>);
-
-        impl<'a, 'b: 'a, 'kvs> Visitor<'kvs> for FmtVisitor<'a, 'b> {
-            fn visit_pair(&mut self, key: Key<'kvs>, value: Value<'kvs>) -> Result<(), Error> {
-                self.0.entry(&key, &value);
-
-                Ok(())
-            }
-        }
-
-        let mut visitor = FmtVisitor(f.debug_map());
+        let mut visitor = f.debug_map();
         self.0.visit(&mut visitor)?;
-        visitor.0.finish()
+        visitor.finish()
     }
 }
 


### PR DESCRIPTION
This PR allows consumers to work around `Value`'s required lifetime constraints in two ways:

1. allowing us to create a value with any lifetime from some owned primitive, like u8, bool etc. This is what the `Primitive` type is all about.
2. allowing us to create a value from some type that _can_ produce a concrete value we can use, but doesn't guarantee it will live as long as the value itself. This is what the `Fill` and `Slot` types are all about.

The `Fill` API is a more advanced initialization strategy (it's _actually_ a kind of visitor that just tries very hard to look like initialization), so it isn't exported from the `log::kv` module. Instead, this PR makes the `value` module public and leaves `Fill` and `Slot` in there. We need something like this to be able to translate a `&'kvs dyn tracing::Value` into a `log::kv::Value<'kvs>`.