### PR TITLE
Prepare for 0.4.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [0.4.7] - 2019-07-06
+
+### New
+
+* Support for embedded environments with thread-unsafe initialization.
+* Initial unstable support for capturing structured data under the `kv_unstable`
+feature gate. This new API doesn't affect existing users and may change in future
+patches (so those changes may not appear in the changelog until it stabilizes).
+
+### Improved
+
+* Docs for using `log` with the 2018 edition.
+* Error messages for macros missing arguments.
+
 ## [0.4.6] - 2018-10-27
 
 ### Improved
@@ -112,7 +126,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.6...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.7...HEAD
+[0.4.7]: https://github.com/rust-lang-nursery/log/compare/0.4.6...0.4.7
 [0.4.6]: https://github.com/rust-lang-nursery/log/compare/0.4.5...0.4.6
 [0.4.5]: https://github.com/rust-lang-nursery/log/compare/0.4.4...0.4.5
 [0.4.4]: https://github.com/rust-lang-nursery/log/compare/0.4.3...0.4.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["rfcs/**/*", "/.travis.yml", "/appveyor.yml"]
 build = "build.rs"
 
 [package.metadata.docs.rs]
-features = ["std", "serde"]
+features = ["std", "serde", "kv_unstable"]
 
 [[test]]
 name = "filters"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.6" # remember to update html_root_url
+version = "0.4.7" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -1,4 +1,16 @@
-//! Structured key-value pairs.
+//! **UNSTABLE:** Structured key-value pairs.
+//! 
+//! This module is unstable and breaking changes may be made
+//! at any time. See [the tracking issue](https://github.com/rust-lang-nursery/log/issues/328)
+//! for more details.
+//! 
+//! Add the `kv_unstable` feature to your `Cargo.toml` to enable
+//! this module:
+//! 
+//! ```toml
+//! [dependencies.log]
+//! features = ["kv_unstable"]
+//! ```
 
 mod error;
 mod source;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.6"
+    html_root_url = "https://docs.rs/log/0.4.7"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
[Current changeset since `0.4.6`](https://github.com/rust-lang-nursery/log/compare/0.4.6...master)

It's been a while since we've done a release and there's a few things sitting on `master` that people want to be able to use.

I've added a note to our current structured logging stuff so it's clear that we're not committing to exactly what's there stability-wise. There are hoops we could make users jump through to access that API besides an unstable feature gate, but that didn't seem really necessary to me.