### PR TITLE
Add structured support to kv::Value using sval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
 matrix:
   include:
-    - rust: 1.21.0
+    - rust: 1.31.0
       script:
         - cargo test --verbose --features kv_unstable
         - cargo test --verbose --features "kv_unstable std"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,31 @@
 language: rust
 sudo: false
 rust:
-  - 1.16.0
   - stable
   - beta
   - nightly
 matrix:
   include:
-    - rust: 1.31.0
-      script:
-        - cargo test --verbose --features kv_unstable
-        - cargo test --verbose --features "kv_unstable std"
     - rust: stable
+      env:
+        - LABEL="Embedded"
       script:
         - rustup target add thumbv6m-none-eabi
         - cargo build --verbose --target=thumbv6m-none-eabi
+    - rust: 1.16.0
+      env:
+        - LABEL="MSRV"
+      script:
+        - cargo build --verbose
+        - cargo build --verbose --features serde
+        - cargo build --verbose --features std
 script:
-  - cargo build --verbose
-  - cargo build --verbose --features serde
-  - cargo build --verbose --features std
   - cargo test --verbose
   - cargo test --verbose --features serde
   - cargo test --verbose --features std
+  - cargo test --verbose --features kv_unstable
+  - cargo test --verbose --features "kv_unstable std"
+  - cargo test --verbose --features "kv_unstable_sval"
   - cargo run --verbose --manifest-path test_max_level_features/Cargo.toml
   - cargo run --verbose --manifest-path test_max_level_features/Cargo.toml --release
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["rfcs/**/*", "/.travis.yml", "/appveyor.yml"]
 build = "build.rs"
 
 [package.metadata.docs.rs]
-features = ["std", "serde", "kv_unstable"]
+features = ["std", "serde", "kv_unstable_sval"]
 
 [[test]]
 name = "filters"
@@ -39,8 +39,9 @@ release_max_level_trace = []
 
 std = []
 
-# requires Rust `>= 1.21.0`
+# requires Rust `>= 1.31.0`
 kv_unstable = []
+kv_unstable_sval = ["kv_unstable", "sval/fmt"]
 
 [badges]
 travis-ci = { repository = "rust-lang-nursery/log" }
@@ -49,6 +50,7 @@ appveyor = { repository = "alexcrichton/log" }
 [dependencies]
 cfg-if = "0.1.2"
 serde = { version = "1.0", optional = true, default-features = false }
+sval = { version = "0.4.2", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ release_max_level_trace = []
 
 std = []
 
-# requires Rust `>= 1.31.0`
+# requires the latest stable
+# this will have a tighter MSRV before stabilization
 kv_unstable = []
 kv_unstable_sval = ["kv_unstable", "sval/fmt"]
 
@@ -54,3 +55,4 @@ sval = { version = "0.4.2", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"
+sval = { version = "0.4.2", features = ["test"] }

--- a/src/kv/value/impls.rs
+++ b/src/kv/value/impls.rs
@@ -241,16 +241,16 @@ mod tests {
 
     #[test]
     fn test_to_value_display() {
-        assert_eq!(42u64.to_value().to_str_buf(), "42");
-        assert_eq!(42i64.to_value().to_str_buf(), "42");
-        assert_eq!(42.01f64.to_value().to_str_buf(), "42.01");
-        assert_eq!(true.to_value().to_str_buf(), "true");
-        assert_eq!('a'.to_value().to_str_buf(), "'a'");
-        assert_eq!(format_args!("a {}", "value").to_value().to_str_buf(), "a value");
-        assert_eq!("a loong string".to_value().to_str_buf(), "\"a loong string\"");
-        assert_eq!(Some(true).to_value().to_str_buf(), "true");
-        assert_eq!(().to_value().to_str_buf(), "None");
-        assert_eq!(Option::None::<bool>.to_value().to_str_buf(), "None");
+        assert_eq!(42u64.to_value().to_string(), "42");
+        assert_eq!(42i64.to_value().to_string(), "42");
+        assert_eq!(42.01f64.to_value().to_string(), "42.01");
+        assert_eq!(true.to_value().to_string(), "true");
+        assert_eq!('a'.to_value().to_string(), "'a'");
+        assert_eq!(format_args!("a {}", "value").to_value().to_string(), "a value");
+        assert_eq!("a loong string".to_value().to_string(), "\"a loong string\"");
+        assert_eq!(Some(true).to_value().to_string(), "true");
+        assert_eq!(().to_value().to_string(), "None");
+        assert_eq!(Option::None::<bool>.to_value().to_string(), "None");
     }
 
     #[test]

--- a/src/kv/value/mod.rs
+++ b/src/kv/value/mod.rs
@@ -133,7 +133,7 @@ mod tests {
             }
         }
 
-        assert_eq!("1", Value::from_fill(&TestFill).to_str_buf());
+        assert_eq!("1", Value::from_fill(&TestFill).to_string());
     }
 
     #[test]
@@ -150,6 +150,6 @@ mod tests {
             }
         }
 
-        let _ = Value::from_fill(&BadFill).to_str_buf();
+        let _ = Value::from_fill(&BadFill).to_string();
     }
 }

--- a/src/kv/value/mod.rs
+++ b/src/kv/value/mod.rs
@@ -102,26 +102,6 @@ impl<'v> Value<'v> {
         }
     }
 
-    /// Get a value from a debuggable type.
-    pub fn from_debug<T>(value: &'v T) -> Self
-    where
-        T: fmt::Debug,
-    {
-        Value {
-            inner: Inner::Debug(value),
-        }
-    }
-
-    /// Get a value from a displayable type.
-    pub fn from_display<T>(value: &'v T) -> Self
-    where
-        T: fmt::Display,
-    {
-        Value {
-            inner: Inner::Display(value),
-        }
-    }
-
     /// Get a value from a fillable slot.
     pub fn from_fill<T>(value: &'v T) -> Self
     where
@@ -134,22 +114,6 @@ impl<'v> Value<'v> {
 
     fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
         self.inner.visit(visitor)
-    }
-}
-
-impl<'v> fmt::Debug for Value<'v> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.visit(&mut self::internal::FmtVisitor(f))?;
-
-        Ok(())
-    }
-}
-
-impl<'v> fmt::Display for Value<'v> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.visit(&mut self::internal::FmtVisitor(f))?;
-
-        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,13 +271,13 @@
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 // When compiled for the rustc compiler itself we want to make sure that this is
 // an unstable crate
 #![cfg_attr(rustbuild, feature(staged_api, rustc_private))]
 #![cfg_attr(rustbuild, unstable(feature = "rustc_private", issue = "27812"))]
 
-#[cfg(not(feature = "std"))]
+#[cfg(all(not(feature = "std"), not(test)))]
 extern crate core as std;
 
 #[macro_use]


### PR DESCRIPTION
# What's this all about?

This PR adds a new unstable feature for structured logging that lets consumers actually interact with the structure of values.

It doesn't do this by exposing its own serialization contract. Instead, it implements traits from a serialization framework called `sval`. I'm open to any philosophical debate on different approaches here!

There are two commits that I think demonstrate how it fits together:

- [Refactor `value` internals so we can add in-band serialization frameworks easily.](https://github.com/rust-lang-nursery/log/commit/15ccf07784fd831adbc2a2b29e78e382c4bbae79)
- [Add `sval` support](https://github.com/rust-lang-nursery/log/commit/06beb05c422e077e51b1f7a1c7b05f01a16885f6). This is the one to look at if you're interested in what impact introducing in-band frameworks has.

# What is `sval`?

[`sval` is a serialization-only framework](https://github.com/sval-rs/sval) I've been working on specifically for use in `log`. `sval` supports no-std, object-safe serialization for primitives and more complex structures like maps and sequences. It absolves `log` from having to produce and maintain its own serialization contract, so it can stay focused, but lets it provide a complete serialization API for consumers.

# What about `serde`?

`serde` is the other serialization framework I've been planning to support in-band in `log` because it's ubiquitous (and does its job very well). I haven't started with it because:

- It'll require `std` to work, because we need `erased-serde`.
- `sval` has out-of-the-box support for `serde` (including in no-std environments) so adding it first already gives consumers a way to capture implementations of `serde::Serialize`.

The plan is to also eventually offer `serde` support.

# Impact on build times

When `sval` is enabled through the `kv_unstable_sval` feature, it increases our compile times by a little bit:

| `log` Features | Dependencies | fresh `cargo build` time (best of 5 runs) |
| -  | - | -  |
| `kv_unstable` | none | 1.28s |
| `kv_unstable_sval` | `sval` | 1.47s |
