### PR TITLE
prepare for 0.4.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.4.8] - 2019-07-28
+
+### New
+
+* Support attempting to get `Record` fields as static strings.
+
 ## [0.4.7] - 2019-07-06
 
 ### New
@@ -126,7 +132,8 @@ version using log 0.4.x to avoid losing module and file information.
 
 Look at the [release tags] for information about older releases.
 
-[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.7...HEAD
+[Unreleased]: https://github.com/rust-lang-nursery/log/compare/0.4.8...HEAD
+[0.4.8]: https://github.com/rust-lang-nursery/log/compare/0.4.7...0.4.8
 [0.4.7]: https://github.com/rust-lang-nursery/log/compare/0.4.6...0.4.7
 [0.4.6]: https://github.com/rust-lang-nursery/log/compare/0.4.5...0.4.6
 [0.4.5]: https://github.com/rust-lang-nursery/log/compare/0.4.4...0.4.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "log"
-version = "0.4.7" # remember to update html_root_url
+version = "0.4.8" # remember to update html_root_url
 authors = ["The Rust Project Developers"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/log/0.4.7"
+    html_root_url = "https://docs.rs/log/0.4.8"
 )]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
[Current changeset since the last release](https://github.com/rust-lang-nursery/log/compare/0.4.7...master)

There's only one new publicly visible and stable change since `0.4.7`: https://github.com/rust-lang-nursery/log/pull/344