### PR TITLE
[WIP] Log macro kv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,11 @@ features = ["std", "serde", "kv_unstable_sval"]
 name = "filters"
 harness = false
 
+[[test]]
+name = "kv_macro"
+required-features = ["kv_unstable"]
+harness = false
+
 [features]
 max_level_off   = []
 max_level_error = []

--- a/src/kv/error.rs
+++ b/src/kv/error.rs
@@ -54,7 +54,7 @@ mod std_support {
     use super::*;
     use std::{error, io};
 
-    pub(super) type BoxedError = Box<error::Error + Send + Sync>;
+    pub(super) type BoxedError = Box<dyn error::Error + Send + Sync>;
 
     impl Error {
         /// Create an error from a standard error type.

--- a/src/kv/value/internal.rs
+++ b/src/kv/value/internal.rs
@@ -12,19 +12,19 @@ pub(super) enum Inner<'v> {
     /// A simple primitive value that can be copied without allocating.
     Primitive(Primitive<'v>),
     /// A value that can be filled.
-    Fill(&'v Fill),
+    Fill(&'v dyn Fill),
     /// A debuggable value.
-    Debug(&'v fmt::Debug),
+    Debug(&'v dyn fmt::Debug),
     /// A displayable value.
-    Display(&'v fmt::Display),
+    Display(&'v dyn fmt::Display),
 
     #[cfg(feature = "kv_unstable_sval")]
     /// A structured value from `sval`.
-    Sval(&'v sval_support::Value),
+    Sval(&'v dyn sval_support::Value),
 }
 
 impl<'v> Inner<'v> {
-    pub(super) fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
+    pub(super) fn visit(&self, visitor: &mut dyn Visitor) -> Result<(), Error> {
         match *self {
             Inner::Primitive(value) => match value {
                 Primitive::Signed(value) => visitor.i64(value),
@@ -47,8 +47,8 @@ impl<'v> Inner<'v> {
 
 /// The internal serialization contract.
 pub(super) trait Visitor {
-    fn debug(&mut self, v: &fmt::Debug) -> Result<(), Error>;
-    fn display(&mut self, v: &fmt::Display) -> Result<(), Error> {
+    fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error>;
+    fn display(&mut self, v: &dyn fmt::Display) -> Result<(), Error> {
         self.debug(&format_args!("{}",  v))
     }
 
@@ -119,7 +119,7 @@ mod fmt_support {
     struct FmtVisitor<'a, 'b: 'a>(&'a mut fmt::Formatter<'b>);
 
     impl<'a, 'b: 'a> Visitor for FmtVisitor<'a, 'b> {
-        fn debug(&mut self, v: &fmt::Debug) -> Result<(), Error> {
+        fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
             v.fmt(self.0)?;
 
             Ok(())

--- a/src/kv/value/mod.rs
+++ b/src/kv/value/mod.rs
@@ -57,7 +57,7 @@ where
 /// A value slot to fill using the [`Fill`](trait.Fill.html) trait.
 pub struct Slot<'a> {
     filled: bool,
-    visitor: &'a mut Visitor,
+    visitor: &'a mut dyn Visitor,
 }
 
 impl<'a> fmt::Debug for Slot<'a> {
@@ -67,7 +67,7 @@ impl<'a> fmt::Debug for Slot<'a> {
 }
 
 impl<'a> Slot<'a> {
-    fn new(visitor: &'a mut Visitor) -> Self {
+    fn new(visitor: &'a mut dyn Visitor) -> Self {
         Slot {
             visitor,
             filled: false,
@@ -112,7 +112,7 @@ impl<'v> Value<'v> {
         }
     }
 
-    fn visit(&self, visitor: &mut Visitor) -> Result<(), Error> {
+    fn visit(&self, visitor: &mut dyn Visitor) -> Result<(), Error> {
         self.inner.visit(visitor)
     }
 }
@@ -127,7 +127,7 @@ mod tests {
 
         impl Fill for TestFill {
             fn fill(&self, slot: &mut Slot) -> Result<(), Error> {
-                let dbg: &fmt::Debug = &1;
+                let dbg: &dyn fmt::Debug = &1;
 
                 slot.fill(Value::from_debug(&dbg))
             }

--- a/src/kv/value/test.rs
+++ b/src/kv/value/test.rs
@@ -26,7 +26,7 @@ impl<'v> Value<'v> {
         struct TestVisitor(Option<Token>);
 
         impl internal::Visitor for TestVisitor {
-            fn debug(&mut self, v: &fmt::Debug) -> Result<(), Error> {
+            fn debug(&mut self, v: &dyn fmt::Debug) -> Result<(), Error> {
                 self.0 = Some(Token::Str(format!("{:?}", v)));
                 Ok(())
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,7 @@ pub mod kv;
 
 // The LOGGER static holds a pointer to the global logger. It is protected by
 // the STATE static which determines whether LOGGER has been initialized yet.
-static mut LOGGER: &'static Log = &NopLogger;
+static mut LOGGER: &'static dyn Log = &NopLogger;
 
 #[allow(deprecated)]
 static STATE: AtomicUsize = ATOMIC_USIZE_INIT;
@@ -747,7 +747,7 @@ pub struct Record<'a> {
 // the underlying `Source`.
 #[cfg(feature = "kv_unstable")]
 #[derive(Clone)]
-struct KeyValues<'a>(&'a kv::Source);
+struct KeyValues<'a>(&'a dyn kv::Source);
 
 #[cfg(feature = "kv_unstable")]
 impl<'a> fmt::Debug for KeyValues<'a> {
@@ -828,7 +828,7 @@ impl<'a> Record<'a> {
     /// The structued key-value pairs associated with the message.
     #[cfg(feature = "kv_unstable")]
     #[inline]
-    pub fn key_values(&self) -> &kv::Source {
+    pub fn key_values(&self) -> &dyn kv::Source {
         self.key_values.0
     }
 
@@ -1002,7 +1002,7 @@ impl<'a> RecordBuilder<'a> {
     /// Set [`key_values`](struct.Record.html#method.key_values)
     #[cfg(feature = "kv_unstable")]
     #[inline]
-    pub fn key_values(&mut self, kvs: &'a kv::Source) -> &mut RecordBuilder<'a> {
+    pub fn key_values(&mut self, kvs: &'a dyn kv::Source) -> &mut RecordBuilder<'a> {
         self.record.key_values = KeyValues(kvs);
         self
     }
@@ -1210,7 +1210,7 @@ pub fn max_level() -> LevelFilter {
 ///
 /// [`set_logger`]: fn.set_logger.html
 #[cfg(all(feature = "std", atomic_cas))]
-pub fn set_boxed_logger(logger: Box<Log>) -> Result<(), SetLoggerError> {
+pub fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), SetLoggerError> {
     set_logger_inner(|| unsafe { &*Box::into_raw(logger) })
 }
 
@@ -1268,14 +1268,14 @@ pub fn set_boxed_logger(logger: Box<Log>) -> Result<(), SetLoggerError> {
 ///
 /// [`set_logger_racy`]: fn.set_logger_racy.html
 #[cfg(atomic_cas)]
-pub fn set_logger(logger: &'static Log) -> Result<(), SetLoggerError> {
+pub fn set_logger(logger: &'static dyn Log) -> Result<(), SetLoggerError> {
     set_logger_inner(|| logger)
 }
 
 #[cfg(atomic_cas)]
 fn set_logger_inner<F>(make_logger: F) -> Result<(), SetLoggerError>
 where
-    F: FnOnce() -> &'static Log,
+    F: FnOnce() -> &'static dyn Log,
 {
     unsafe {
         match STATE.compare_and_swap(UNINITIALIZED, INITIALIZING, Ordering::SeqCst) {
@@ -1312,7 +1312,7 @@ where
 /// (including all logging macros).
 ///
 /// [`set_logger`]: fn.set_logger.html
-pub unsafe fn set_logger_racy(logger: &'static Log) -> Result<(), SetLoggerError> {
+pub unsafe fn set_logger_racy(logger: &'static dyn Log) -> Result<(), SetLoggerError> {
     match STATE.load(Ordering::SeqCst) {
         UNINITIALIZED => {
             LOGGER = logger;
@@ -1372,7 +1372,7 @@ impl error::Error for ParseLevelError {
 /// Returns a reference to the logger.
 ///
 /// If a logger has not been set, a no-op implementation is returned.
-pub fn logger() -> &'static Log {
+pub fn logger() -> &'static dyn Log {
     unsafe {
         if STATE.load(Ordering::SeqCst) != INITIALIZED {
             static NOP: NopLogger = NopLogger;

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use log::set_boxed_logger;
 
 #[cfg(not(feature = "std"))]
-fn set_boxed_logger(logger: Box<Log>) -> Result<(), log::SetLoggerError> {
+fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), log::SetLoggerError> {
     log::set_logger(unsafe { &*Box::into_raw(logger) })
 }
 

--- a/tests/kv_macro.rs
+++ b/tests/kv_macro.rs
@@ -1,0 +1,53 @@
+#[macro_use]
+extern crate log;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use log::{Level, Log, LevelFilter, Metadata, Record};
+use log::kv::Key;
+
+#[cfg(feature = "std")]
+use log::set_boxed_logger;
+
+#[cfg(not(feature = "std"))]
+fn set_boxed_logger(logger: Box<dyn Log>) -> Result<(), log::SetLoggerError> {
+    log::set_logger(unsafe { &*Box::into_raw(logger) })
+}
+
+fn main() {
+    let ran = Arc::new(AtomicBool::new(false));
+    set_boxed_logger(Box::new(Logger(Arc::clone(&ran)))).unwrap();
+    log::set_max_level(LevelFilter::Info);
+
+    log!(target: __log_module_path!(), Level::Info, "some {} message {}", "great", 1, {
+        key1: "Some value",
+        key2: 2,
+    });
+
+    assert!(ran.load(Ordering::Acquire), "logger didn't run");
+}
+
+struct Logger(Arc<AtomicBool>);
+
+impl Log for Logger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        self.0.store(true, Ordering::Release);
+
+        assert_eq!(record.level(), Level::Info);
+        assert_eq!(record.target(), "kv_macro");
+        assert_eq!(record.module_path(), Some("kv_macro"));
+        assert_eq!(record.file(), Some("tests/kv_macro.rs"));
+        assert_eq!(record.line(), Some(23));
+        let kvs = record.key_values();
+        assert_eq!(kvs.count(), 2);
+        assert_eq!(kvs.get(Key::from_str("key1")).unwrap().to_string(), "Some value");
+        assert_eq!(kvs.get(Key::from_str("key2")).unwrap().to_string(), "2");
+    }
+
+    fn flush(&self) {}
+}


### PR DESCRIPTION
This is my attempt at modifying the `log` macro to add support for key values, as described in https://github.com/rust-lang-nursery/log/issues/343#issuecomment-513759469. I didn't get very far as I'm not the best at Rust macros.

Testing with `cargo test --features std kv_unstable` gives the following error:

```log
error: local ambiguity: multiple parsing options: built-in NTs tt ('arg') or 1 other option.
  --> tests/kv_macro.rs:23:87
   |
23 |     log!(target: __log_module_path!(), Level::Info, "some {} message {}", "great", 1, {
   |                                                                                       ^
```

For #343.

/cc @KodrAus @yoshuawuyts