### PR TITLE
inline docs for kv::value

### DIFF
--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -1,23 +1,26 @@
 //! **UNSTABLE:** Structured key-value pairs.
-//! 
+//!
 //! This module is unstable and breaking changes may be made
 //! at any time. See [the tracking issue](https://github.com/rust-lang-nursery/log/issues/328)
 //! for more details.
-//! 
+//!
 //! Add the `kv_unstable` feature to your `Cargo.toml` to enable
 //! this module:
-//! 
+//!
 //! ```toml
 //! [dependencies.log]
 //! features = ["kv_unstable"]
 //! ```
 
 mod error;
-mod source;
 mod key;
+mod source;
+
 pub mod value;
 
 pub use self::error::Error;
-pub use self::source::{Source, Visitor};
 pub use self::key::{Key, ToKey};
-pub use self::value::{Value, ToValue};
+pub use self::source::{Source, Visitor};
+
+#[doc(inline)]
+pub use self::value::{ToValue, Value};


### PR DESCRIPTION
This inlines the docs for all `kv::value` subtypes which should make it easier to read & dicscover. Thanks!

_edit: a few lines have been shuffled around because rustfmt ran from my editor. Hope that's okay!_

## Proposed

![Screenshot_2019-09-01 log kv - Rust(2)](https://user-images.githubusercontent.com/2467194/64074729-7c675280-ccaf-11e9-8e67-fb9edd9564b4.png)

## Current

![Screenshot_2019-09-01 log kv - Rust(1)](https://user-images.githubusercontent.com/2467194/64074732-8b4e0500-ccaf-11e9-9155-de39383d8292.png)
